### PR TITLE
v5.0.437 docs follow-up: document AI-agent discovery + em-dash work, fix stale counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If your project isn't in a git repo, add `.mcp.json` manually to your project ro
 | `create_extension` | Scaffold a full extension (COMP + DAT + wiring) |
 | `get_op_errors` | Inspect errors on any operator and its children |
 
-...and 37 more. See the [full tools reference](https://dylanroscover.github.io/Embody/envoy/tools-reference/).
+...and 42 more. See the [full tools reference](https://dylanroscover.github.io/Embody/envoy/tools-reference/).
 
 When Envoy starts, it generates a `CLAUDE.md` file in your project root with TD development patterns, the complete MCP tool reference, and project-specific guidance.
 

--- a/dev/embody/unit_tests/test_git_status.py
+++ b/dev/embody/unit_tests/test_git_status.py
@@ -1,5 +1,5 @@
 """Pure-logic tests for EmbodyExt's git-uncommitted status helpers
-(_parseGitPorcelain, _gitRelPath, _rowHasChanges). These drive the static
+(_parseGitPorcelain, _mapChangedToOps, _rowHasChanges). These drive the static
 methods directly with fixtures -- no git repo, no sandbox operators --
 referencing the extension inline per the no-ext-caching rule.
 """

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,11 @@ A second status axis in the manager -- **git-uncommitted** -- so every externali
 - **Hardened via a 3-agent codex review (no regressions found).** The background scan now runs `git --no-optional-locks status --untracked-files=all` so it never contends for `.git/index.lock` with a concurrent `git add`/`commit` and so a newly externalized file inside a brand-new folder is enumerated (not collapsed to `?? dir/`). The async completion is **generation-guarded** with task-local result state, so a stale scan that fires after a re-arm can never clobber a newer one (or leak its in-flight flag). The hover/rollover state keeps the orange precedence for uncommitted saved rows, and the `tag` label is lowercase there too.
 - **Tests:** new `test_git_status.py` covers the porcelain parser, the file-to-repo path mapping, and the `changed` predicate -- pure logic, no live TD.
 
+### Also rolled up in this release (since v5.0.429)
+
+- **AI-agent discovery surface at embody.tools.** Machine-readable entry points so AI coding assistants can adopt Embody without scraping marketing HTML: an `llms.txt` convention index plus a `llms-full.txt` full corpus, a `/for-ai` page with structured `for-ai.json` / `for-ai.txt` endpoints, and schema.org `SoftwareApplication` JSON-LD across the landing pages.
+- **Em-dash mojibake fix + ASCII-punctuation rule.** Fixed a CP1252 round-trip corruption in shipped `execute.py` (two comments where a UTF-8 em-dash had been re-saved as mojibake), normalized generated/code/config files repo-wide to ASCII punctuation (BOMs preserved; hand-written docs prose exempt), and added a shipped `.claude/rules/ascii-punctuation.md` rule to keep it that way.
+
 ## v5.0.434
 
 A new `diff_tdn` MCP tool for what's UNSAVED in a TDN network -- one COMP or the whole project -- plus a companion git diff driver that keeps committed `.tdn` diffs clean, a project-wide hard rule against caching extension references (with an enforcing test), and a fix for the recurring "TouchDesigner is not responding" error during saves.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Embody includes a comprehensive automated test suite with **60 test suites** and **1,449 test methods** covering core externalization, MCP tools, TDN format, the Envoy server/bridge, and palette catalogs. Tests run inside TouchDesigner using a custom test runner with sandbox isolation.
+Embody includes a comprehensive automated test suite with **61 test suites** and **1,469 test methods** covering core externalization, MCP tools, TDN format, the Envoy server/bridge, and palette catalogs. Tests run inside TouchDesigner using a custom test runner with sandbox isolation.
 
 ## Running Tests
 


### PR DESCRIPTION
Post-release documentation follow-up for v5.0.437, from a 4-dimension release audit.

The v5.0.437 release shipped two substantive changes that were **undocumented** in the changelog/release notes -- the same class of gap that initially hit `diff_tdn`:
- **AI-agent discovery surface** -- `llms.txt` / `llms-full.txt`, the `/for-ai` page + `for-ai.json`/`for-ai.txt` endpoints, schema.org `SoftwareApplication` JSON-LD (served at embody.tools)
- **Em-dash mojibake fix + ascii-punctuation rule** -- CP1252 round-trip corruption fixed in shipped `execute.py`, repo-wide ASCII-punctuation normalization, new shipped `.claude/rules/ascii-punctuation.md`

Both are now documented under the v5.0.437 changelog entry, and the **published GitHub release notes are already updated** to match.

Also fixes stale figures the audit caught:
- `docs/testing.md`: 60/1,449 -> 61/1,469
- README: "and 37 more" -> "and 42 more" (49 MCP tools - 7 shown)
- `test_git_status.py` docstring: `_gitRelPath` -> `_mapChangedToOps` (stale after the async-fix refactor)

### Known gaps the audit flagged (not addressed here)
- The full suite was **not** re-run against the final post-codex-fix code (blocked: dev TD's Envoy is currently down). Affected suites were verified individually (`test_git_status` 20/20, `test_claude_config` 71/71).
- The new **async git-status orchestration** (worker thread, generation guard, no-git / pool-exhaustion / coalescing paths) has **no automated test coverage** -- `test_git_status.py` covers only the pure statics. Recommended as a focused follow-up (fake-ThreadManager pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
