### PR TITLE
web: user avatars -- GitHub-seeded default + uploadable override

### DIFF
--- a/platform/apps/web/e2e/avatar.spec.ts
+++ b/platform/apps/web/e2e/avatar.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+// User avatars: sign up a fresh account, then exercise the upload -> serve ->
+// render -> validate -> remove loop. The upload is driven by an in-page authed
+// fetch of a canvas-generated WebP (not the file-input UI), so the test is
+// immune to dev-server client-script flakiness; the RENDER assertions are SSR.
+test("avatar upload, serve, render, validation, and remove", async ({ page }) => {
+  const email = `e2e-avatar-${Date.now().toString(36)}@example.com`;
+
+  // Sign up (dev: no email provider -> auto signed in).
+  await page.goto("/signin");
+  await page.click('button[data-mode="register"]');
+  await page.fill('input[name="name"]', "Avatar E2E");
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', "sup3rsecret!");
+  await page.click('button[data-auth-submit]');
+
+  // The profile link lives in the (collapsed) account menu, so it's attached but
+  // not visible until the menu opens -- we only need its href, which proves the
+  // session is live.
+  const profileLink = page.locator('a[href^="/u/"]').first();
+  await profileLink.waitFor({ state: "attached", timeout: 15_000 });
+  const href = await profileLink.getAttribute("href");
+  expect(href).toBeTruthy();
+
+  await page.goto(href!);
+
+  // Upload a real (canvas-encoded) WebP through the authed route.
+  const upload = await page.evaluate(async () => {
+    const c = document.createElement("canvas");
+    c.width = 256;
+    c.height = 256;
+    const ctx = c.getContext("2d")!;
+    ctx.fillStyle = "#6ee668";
+    ctx.fillRect(0, 0, 256, 256);
+    const res = await fetch("/api/account/avatar", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar: c.toDataURL("image/webp", 0.85) })
+    });
+    return { status: res.status, body: (await res.json()) as { avatar_url?: string } };
+  });
+  expect(upload.status).toBe(200);
+  expect(upload.body.avatar_url).toMatch(/^\/api\/avatars\/[a-f0-9]{64}$/);
+
+  // The serve route returns the immutable image.
+  const served = await page.request.get(upload.body.avatar_url!);
+  expect(served.status()).toBe(200);
+  expect(served.headers()["content-type"]).toContain("image/");
+  expect(served.headers()["cache-control"]).toContain("immutable");
+
+  // Profile + nav both render the avatar as an <img> after reload (SSR).
+  await page.goto(href!);
+  await expect(page.locator(".profile-avatar img[data-avatar-img]")).toHaveAttribute(
+    "src",
+    upload.body.avatar_url!
+  );
+  await expect(page.locator(".navbar__user-avatar")).toHaveJSProperty("tagName", "IMG");
+
+  // A non-image payload is rejected.
+  const bad = await page.evaluate(async () => {
+    const res = await fetch("/api/account/avatar", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar: "data:text/plain;base64,aGVsbG8=" })
+    });
+    return res.status;
+  });
+  expect(bad).toBe(400);
+
+  // Remove reverts to the letter chip (this account has no GitHub avatar).
+  const removed = await page.evaluate(async () => {
+    const res = await fetch("/api/account/avatar", { method: "DELETE" });
+    return res.status;
+  });
+  expect(removed).toBe(200);
+  await page.goto(href!);
+  await expect(page.locator(".profile-avatar span.avatar--initial")).toBeVisible();
+  await expect(page.locator(".profile-avatar img[data-avatar-img]")).toHaveCount(0);
+});

--- a/platform/apps/web/src/layouts/Base.astro
+++ b/platform/apps/web/src/layouts/Base.astro
@@ -137,7 +137,11 @@ const cfBeaconToken = import.meta.env.PUBLIC_CF_BEACON_TOKEN as string | undefin
                 aria-expanded="false"
                 aria-label={`Account menu for ${displayName}`}
               >
-                <span class="navbar__user-avatar" aria-hidden="true">{userInitials}</span>
+                {user.avatarUrl ? (
+                  <img class="navbar__user-avatar navbar__user-avatar--img" src={user.avatarUrl} alt="" aria-hidden="true" />
+                ) : (
+                  <span class="navbar__user-avatar" aria-hidden="true">{userInitials}</span>
+                )}
                 <span class="navbar__user-name">{displayName}</span>
               </button>
               <div class="navbar__user-menu" data-user-menu-list role="menu" hidden>

--- a/platform/apps/web/src/lib/auth.ts
+++ b/platform/apps/web/src/lib/auth.ts
@@ -99,11 +99,19 @@ function buildAuth(env: AuthEnv, secret: string) {
     databaseHooks: {
       user: {
         create: {
-          after: async (user: { id: string; email?: string | null; name?: string | null }) => {
+          after: async (user: {
+            id: string;
+            email?: string | null;
+            name?: string | null;
+            image?: string | null;
+          }) => {
             const handle = await ensureUserProfile(env.DB, {
               id: user.id,
               email: user.email,
-              name: user.name
+              name: user.name,
+              // GitHub OAuth populates user.image with the avatar URL; seed it so
+              // social sign-ups get a real avatar immediately. Null for email/pw.
+              image: user.image
             });
             // Operational notice to the owner. Safe-by-default + self-swallowing,
             // so it never blocks or breaks account creation (see notifications.ts).
@@ -147,7 +155,7 @@ export function getAuth(env: AuthEnv): AuthInstance {
 // backfilled lazily by ensureProfileForSession() on first authed request.
 export async function ensureUserProfile(
   db: D1Database,
-  user: { id: string; email?: string | null; name?: string | null }
+  user: { id: string; email?: string | null; name?: string | null; image?: string | null }
 ): Promise<string | null> {
   try {
     const existing = await db
@@ -160,10 +168,10 @@ export async function ensureUserProfile(
 
     await db
       .prepare(
-        `INSERT OR IGNORE INTO users_profile (id, handle, trust_level)
-         VALUES (?, ?, 'verified')`
+        `INSERT OR IGNORE INTO users_profile (id, handle, trust_level, avatar_url)
+         VALUES (?, ?, 'verified', ?)`
       )
-      .bind(user.id, handle)
+      .bind(user.id, handle, user.image ?? null)
       .run();
 
     // If the INSERT was ignored due to a race, read back the live handle.

--- a/platform/apps/web/src/lib/authSession.ts
+++ b/platform/apps/web/src/lib/authSession.ts
@@ -11,6 +11,9 @@ export interface SessionUser {
   name: string;
   image: string | null;
   trustLevel: string;
+  // Effective avatar to render (users_profile.avatar_url): a GitHub avatar seeded
+  // at sign-up / backfilled here, or an uploaded one, or null -> letter chip.
+  avatarUrl: string | null;
 }
 
 // Resolve the current session (if any) into a SessionUser, backfilling the
@@ -34,30 +37,51 @@ export async function getSessionUser(
 
   let handle: string | null = null;
   let trustLevel = "verified";
+  let avatarUrl: string | null = null;
   try {
     const row = await env.DB.prepare(
-      "SELECT handle, trust_level FROM users_profile WHERE id = ? LIMIT 1"
+      "SELECT handle, trust_level, avatar_url FROM users_profile WHERE id = ? LIMIT 1"
     )
       .bind(user.id)
-      .first<{ handle: string; trust_level: string }>();
+      .first<{ handle: string; trust_level: string; avatar_url: string | null }>();
     if (row?.handle) {
       handle = row.handle;
       trustLevel = row.trust_level ?? "verified";
+      avatarUrl = row.avatar_url;
     }
   } catch (error) {
     console.error("getSessionUser: profile lookup failed", error);
   }
 
-  // Backfill if the profile row is missing.
+  // Backfill if the profile row is missing (created before the hook, or a failed
+  // hook insert). ensureUserProfile seeds the GitHub avatar too.
   if (!handle) {
     handle = await ensureUserProfile(env.DB, {
       id: user.id,
       email: user.email,
-      name: user.name
+      name: user.name,
+      image: user.image
     });
+    avatarUrl = user.image ?? null;
   }
 
   if (!handle) return null;
+
+  // Lazy GitHub-avatar backfill: an account that predates avatars (or signed up
+  // before user.image resolved) gets its avatar_url seeded on first authed
+  // request. Only fills a NULL -- never clobbers an explicit upload. Best-effort.
+  if (!avatarUrl && user.image) {
+    avatarUrl = user.image;
+    try {
+      await env.DB.prepare(
+        "UPDATE users_profile SET avatar_url = ? WHERE id = ? AND avatar_url IS NULL"
+      )
+        .bind(user.image, user.id)
+        .run();
+    } catch (error) {
+      console.error("getSessionUser: avatar backfill failed", error);
+    }
+  }
 
   return {
     id: user.id,
@@ -65,6 +89,7 @@ export async function getSessionUser(
     email: user.email ?? "",
     name: user.name ?? "",
     image: user.image ?? null,
-    trustLevel
+    trustLevel,
+    avatarUrl
   };
 }

--- a/platform/apps/web/src/pages/api/account/avatar.ts
+++ b/platform/apps/web/src/pages/api/account/avatar.ts
@@ -1,0 +1,61 @@
+import { env } from "cloudflare:workers";
+import type { APIRoute } from "astro";
+import { getRequestUser } from "../../../server/auth";
+import { setProfileAvatarUrl } from "../../../server/db";
+import { putAvatar } from "../../../server/r2";
+import { errorResponse, jsonResponse, serverErrorResponse } from "../../../server/http";
+
+export const prerender = false;
+
+// POST /api/account/avatar -- the signed-in user uploads a new avatar. Body is
+// { avatar: <data URL> }; the client downscales/squares the image to a small
+// PNG/JPEG/WebP before sending. The blob is stored content-addressed in R2
+// (avatars/<sha256>) and users_profile.avatar_url is set to the serve URL, which
+// overrides the GitHub-seeded avatar. Returns { avatar_url }.
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const user = await getRequestUser(request, env);
+    if (!user) return errorResponse(401, "unauthorized", "Sign in to set an avatar.");
+
+    let body: { avatar?: unknown };
+    try {
+      body = (await request.json()) as { avatar?: unknown };
+    } catch {
+      return errorResponse(400, "invalid_body", "Expected a JSON body with an avatar data URL.");
+    }
+
+    const dataUrl = typeof body.avatar === "string" ? body.avatar : undefined;
+    // putAvatar returns null for a non-image, oversized, or unparseable payload.
+    const stored = await putAvatar(env.BLOBS, dataUrl);
+    if (!stored) {
+      return errorResponse(
+        400,
+        "invalid_avatar",
+        "Avatar must be a PNG, JPEG, or WebP image under 0.5 MB."
+      );
+    }
+
+    const avatarUrl = `/api/avatars/${stored.sha256}`;
+    await setProfileAvatarUrl(env.DB, user.id, avatarUrl);
+    return jsonResponse({ avatar_url: avatarUrl });
+  } catch (error) {
+    console.error("POST /api/account/avatar failed", error);
+    return serverErrorResponse();
+  }
+};
+
+// DELETE /api/account/avatar -- remove the custom avatar. Clears avatar_url; on
+// the next authed request getSessionUser re-seeds the GitHub avatar if there is
+// one (so "remove" reverts to the GitHub default, else the letter chip).
+export const DELETE: APIRoute = async ({ request }) => {
+  try {
+    const user = await getRequestUser(request, env);
+    if (!user) return errorResponse(401, "unauthorized", "Sign in to change your avatar.");
+
+    await setProfileAvatarUrl(env.DB, user.id, null);
+    return jsonResponse({ avatar_url: null });
+  } catch (error) {
+    console.error("DELETE /api/account/avatar failed", error);
+    return serverErrorResponse();
+  }
+};

--- a/platform/apps/web/src/pages/api/avatars/[hash].ts
+++ b/platform/apps/web/src/pages/api/avatars/[hash].ts
@@ -1,0 +1,36 @@
+import { env } from "cloudflare:workers";
+import type { APIRoute } from "astro";
+import { getAvatar } from "../../../server/r2";
+import { errorResponse, serverErrorResponse } from "../../../server/http";
+
+export const prerender = false;
+
+// GET /api/avatars/:hash -- serve an uploaded avatar blob from R2. The hash is the
+// sha256 of the image bytes (content-addressed), so the response is immutable and
+// safe to cache for a year: a new upload yields a new hash + URL. 404 when the
+// blob is missing. Avatars are public, so no auth gate.
+const HASH_RE = /^[a-f0-9]{64}$/;
+
+export const GET: APIRoute = async ({ params }) => {
+  try {
+    const hash = params.hash;
+    if (!hash || !HASH_RE.test(hash)) {
+      return errorResponse(400, "invalid_avatar", "Malformed avatar id.");
+    }
+
+    const object = await getAvatar(env.BLOBS, hash);
+    if (!object) return errorResponse(404, "avatar_not_found", "No avatar for that id.");
+
+    return new Response(object.body, {
+      status: 200,
+      headers: {
+        "Content-Type": object.httpMetadata?.contentType || "image/png",
+        "Cache-Control": "public, max-age=31536000, immutable",
+        ETag: object.httpEtag
+      }
+    });
+  } catch (error) {
+    console.error("GET /api/avatars/[hash] failed", error);
+    return serverErrorResponse();
+  }
+};

--- a/platform/apps/web/src/pages/u/[handle].astro
+++ b/platform/apps/web/src/pages/u/[handle].astro
@@ -39,6 +39,10 @@ const totalCopies = specimens.reduce((sum, item) => sum + item.copies_count, 0);
 const memberSince = profile ? memberYear(profile.created_at) : "";
 const avatarInitial = profile ? initialFor(profile.handle) : "?";
 
+// The viewer can edit the avatar only on their OWN profile.
+const viewer = Astro.locals.user;
+const isOwn = Boolean(viewer && profile && viewer.handle === profile.handle);
+
 function initialFor(value: string): string {
   const cleaned = value.replace(/[^a-z0-9]/gi, "");
   return (cleaned[0] ?? value[0] ?? "?").toUpperCase();
@@ -62,11 +66,31 @@ function pluralize(count: number, singular: string): string {
     >
       <section class="page-section profile-header">
         <div class="profile-id">
-          {profile.avatar_url ? (
-            <img class="avatar avatar--img" src={profile.avatar_url} alt={`@${profile.handle}`} />
-          ) : (
-            <span class="avatar avatar--initial" aria-hidden="true">{avatarInitial}</span>
-          )}
+          <div class="profile-avatar" data-avatar-shell={isOwn ? "" : undefined} data-avatar-initial={avatarInitial}>
+            {profile.avatar_url ? (
+              <img class="avatar avatar--img" src={profile.avatar_url} alt={`@${profile.handle}`} data-avatar-img />
+            ) : (
+              <span class="avatar avatar--initial" aria-hidden="true" data-avatar-img>{avatarInitial}</span>
+            )}
+            {isOwn && (
+              <div class="avatar-edit">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  hidden
+                  data-avatar-input
+                />
+                <button type="button" class="avatar-edit__btn" data-avatar-pick>change</button>
+                <button
+                  type="button"
+                  class="avatar-edit__btn avatar-edit__btn--remove"
+                  data-avatar-remove
+                  hidden={!profile.avatar_url}
+                >remove</button>
+                <span class="avatar-edit__status mono" data-avatar-status aria-live="polite"></span>
+              </div>
+            )}
+          </div>
           <div class="profile-meta">
             <p class="eyebrow">Contributor</p>
             <h1>@{profile.handle}</h1>
@@ -163,6 +187,68 @@ function pluralize(count: number, singular: string): string {
     background: var(--accent-dim);
     color: var(--accent);
     font: 600 clamp(2.25rem, 5vw, 3.25rem)/1 var(--font-display);
+  }
+
+  /* Avatar column: the image/initial plus the owner-only edit controls below. */
+  .profile-avatar {
+    flex: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.55rem;
+  }
+
+  .avatar-edit {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+  }
+
+  .avatar-edit__btn {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: rgba(24, 30, 30, 0.72);
+    padding: 0.22rem 0.62rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    transition: border-color 140ms ease, color 140ms ease;
+  }
+
+  .avatar-edit__btn:hover {
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  .avatar-edit__btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .avatar-edit__btn--remove {
+    color: var(--text-faint);
+  }
+
+  .avatar-edit__btn--remove:hover {
+    border-color: #c46b6b;
+    color: #c46b6b;
+  }
+
+  .avatar-edit__status {
+    flex-basis: 100%;
+    text-align: center;
+    color: var(--text-faint);
+    font-size: 0.6rem;
+    letter-spacing: 0.04em;
+  }
+
+  .avatar-edit__status.is-error {
+    color: #c46b6b;
   }
 
   .profile-meta {
@@ -295,3 +381,86 @@ function pluralize(count: number, singular: string): string {
     }
   }
 </style>
+
+<script>
+  // Owner-only avatar upload/remove. The shell only renders on your OWN profile,
+  // so a missing shell makes this a no-op everywhere else. The picked image is
+  // squared + downscaled to 256px on a canvas (so we never ship a huge file or a
+  // non-square crop), POSTed as a WebP data URL, then the page reloads to show the
+  // canonical state (upload, or the re-seeded GitHub default / letter chip).
+  const shell = document.querySelector<HTMLElement>("[data-avatar-shell]");
+  if (shell) {
+    const input = shell.querySelector<HTMLInputElement>("[data-avatar-input]");
+    const pick = shell.querySelector<HTMLButtonElement>("[data-avatar-pick]");
+    const remove = shell.querySelector<HTMLButtonElement>("[data-avatar-remove]");
+    const status = shell.querySelector<HTMLElement>("[data-avatar-status]");
+    const MAX_INPUT_BYTES = 8 * 1024 * 1024; // reject absurd sources before decoding
+
+    const setStatus = (msg: string, isError = false): void => {
+      if (!status) return;
+      status.textContent = msg;
+      status.classList.toggle("is-error", isError);
+    };
+    const setBusy = (busy: boolean): void => {
+      for (const el of [pick, remove]) if (el) el.disabled = busy;
+    };
+
+    async function squareDataUrl(file: File): Promise<string> {
+      const bitmap = await createImageBitmap(file);
+      const SIZE = 256;
+      const canvas = document.createElement("canvas");
+      canvas.width = SIZE;
+      canvas.height = SIZE;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("canvas unavailable");
+      const min = Math.min(bitmap.width, bitmap.height);
+      const sx = (bitmap.width - min) / 2;
+      const sy = (bitmap.height - min) / 2;
+      ctx.drawImage(bitmap, sx, sy, min, min, 0, 0, SIZE, SIZE);
+      bitmap.close();
+      return canvas.toDataURL("image/webp", 0.85);
+    }
+
+    pick?.addEventListener("click", () => input?.click());
+
+    input?.addEventListener("change", async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      if (file.size > MAX_INPUT_BYTES) {
+        setStatus("image too large", true);
+        input.value = "";
+        return;
+      }
+      setBusy(true);
+      setStatus("uploading...");
+      try {
+        const avatar = await squareDataUrl(file);
+        const res = await fetch("/api/account/avatar", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ avatar })
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        window.location.reload();
+      } catch {
+        setStatus("upload failed -- try a PNG/JPEG/WebP under 0.5 MB", true);
+        setBusy(false);
+      } finally {
+        input.value = "";
+      }
+    });
+
+    remove?.addEventListener("click", async () => {
+      setBusy(true);
+      setStatus("removing...");
+      try {
+        const res = await fetch("/api/account/avatar", { method: "DELETE" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        window.location.reload();
+      } catch {
+        setStatus("remove failed", true);
+        setBusy(false);
+      }
+    });
+  }
+</script>

--- a/platform/apps/web/src/server/db.ts
+++ b/platform/apps/web/src/server/db.ts
@@ -465,6 +465,19 @@ export async function getUserByHandle(
   return fallbackUserProfile(trimmed);
 }
 
+// Set (or clear with null) a user's effective avatar_url. Used by the avatar
+// upload/remove routes; clearing reverts every avatar site to the letter chip.
+export async function setProfileAvatarUrl(
+  db: D1Database,
+  userId: string,
+  avatarUrl: string | null
+): Promise<void> {
+  await db
+    .prepare("UPDATE users_profile SET avatar_url = ? WHERE id = ?")
+    .bind(avatarUrl, userId)
+    .run();
+}
+
 export async function listSpecimensByAuthor(
   db: D1Database,
   handle: string

--- a/platform/apps/web/src/server/r2.ts
+++ b/platform/apps/web/src/server/r2.ts
@@ -62,6 +62,42 @@ export async function putThumbnail(
   return { key, sha256 };
 }
 
+// Avatars: content-addressed under avatars/<sha256>, uploaded as a data URL just
+// like thumbnails. Content addressing means a re-upload gets a NEW key, so the
+// serve URL changes and no cache-busting is needed. Returns null on a non-image,
+// oversized, or unparseable payload so the route can answer 400 cleanly.
+const AVATAR_MAX_BYTES = 512 * 1024; // 0.5 MB -- avatars are downscaled client-side
+const AVATAR_CONTENT_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+export async function putAvatar(
+  blobs: R2Bucket,
+  dataUrl: string | undefined
+): Promise<BlobWrite | null> {
+  if (!dataUrl) return null;
+
+  const parsed = parseDataUrl(dataUrl);
+  if (!parsed) return null;
+  if (!AVATAR_CONTENT_TYPES.has(parsed.contentType)) return null;
+  if (parsed.bytes.byteLength === 0 || parsed.bytes.byteLength > AVATAR_MAX_BYTES) return null;
+
+  const sha256 = await sha256Hex(parsed.bytes);
+  const key = `avatars/${sha256}`;
+
+  await blobs.put(key, parsed.bytes, {
+    httpMetadata: { contentType: parsed.contentType },
+    customMetadata: { sha256 }
+  });
+
+  return { key, sha256 };
+}
+
+// Fetch a stored avatar blob for streaming. `sha256` is the bare hash from the
+// serve URL; null when empty or missing.
+export async function getAvatar(blobs: R2Bucket, sha256: string): Promise<R2ObjectBody | null> {
+  if (!sha256) return null;
+  return blobs.get(`avatars/${sha256}`);
+}
+
 export function byteLength(value: string): number {
   return encoder.encode(value).byteLength;
 }

--- a/platform/apps/web/src/styles/embody.css
+++ b/platform/apps/web/src/styles/embody.css
@@ -491,6 +491,12 @@ pre {
   letter-spacing: 0;
 }
 
+/* Uploaded / GitHub avatar image variant: fill the same circular chip. */
+.navbar__user-avatar--img {
+  object-fit: cover;
+  background: var(--bg-code);
+}
+
 .navbar__user-menu {
   position: absolute;
   top: calc(100% + 0.5rem);


### PR DESCRIPTION
Adds real user avatars across embody.tools, replacing the letter-chip wherever a real image exists (the chip stays as the fallback, so nothing ever breaks).

## Source model: GitHub default + upload override
- **GitHub default** -- better-auth populates `user.image` with the GitHub avatar on social sign-up; `ensureUserProfile` seeds `users_profile.avatar_url` from it, and `getSessionUser` lazily backfills any NULL `avatar_url` from the session image (covers accounts created before avatars). Best-effort -- never blocks sign-up.
- **Upload override** -- `POST /api/account/avatar` takes a client-squared/downscaled 256px WebP data URL, stores it content-addressed in R2 (`avatars/<sha256>`, so a re-upload yields a new immutable URL -- no cache-busting), and points `avatar_url` at `GET /api/avatars/<sha256>`. `DELETE` clears it, reverting to the GitHub default (or the letter chip). Validates image type + 0.5 MB cap.

## Render
`SessionUser` gains `avatarUrl`; the nav account chip and the `/u/<handle>` profile header render `<img>` when set, else the initial. Owner-only change/remove controls on the profile (canvas square-crop -> WebP -> POST -> reload).

## Verification
Verified end-to-end against a **production build**: sign-up, UI upload, serve (`200`, `image/webp`, `immutable`), render in nav + profile, non-image rejected `400`, remove reverts. `e2e/avatar.spec.ts` guards the loop. **CI gate green**: typecheck (0 errors) + build + scanner tests (31/31).

## Caveats for review
- **GitHub seed/backfill is not exercisable in local dev** (no OAuth creds). The logic is additive + self-swallowing; worth a glance on the first real GitHub sign-in after deploy.
- No DB migration needed -- `users_profile.avatar_url` already existed.

## Deferred follow-ups
- Collection-card **author** avatars (needs `author_avatar_url` on `SpecimenSummary`; the `users_profile` join already exists).
- **Admin moderation** of avatars (new user-content surface).

## Files
- New: `api/account/avatar.ts` (POST/DELETE), `api/avatars/[hash].ts` (GET serve), `e2e/avatar.spec.ts`
- Changed: `lib/auth.ts`, `lib/authSession.ts`, `server/r2.ts`, `server/db.ts`, `layouts/Base.astro`, `pages/u/[handle].astro`, `styles/embody.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)