### PR TITLE
CI: SHA-pin Actions, add zizmor security gate + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  # GitHub Actions across all workflows (.github/workflows/*). Dependabot bumps
+  # the pinned commit SHA and its trailing "# vX.Y.Z" comment together. All
+  # action bumps are grouped into a single weekly PR (like the manual #34).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci
+
+  # Node dependencies for the platform monorepo (Astro web app + workspaces),
+  # resolved from the root lockfile at platform/package-lock.json. Minor/patch
+  # bumps are grouped; majors (e.g. wrangler v4 -> v5) open their own PR so the
+  # breaking-change review stays isolated.
+  - package-ecosystem: npm
+    directory: /platform
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,8 @@ on:
       - 'mkdocs.yml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Least-privilege default: grant nothing at the top level, widen per job.
+permissions: {}
 
 concurrency:
   group: "pages"
@@ -21,10 +19,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -35,17 +37,22 @@ jobs:
         run: mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    # deploy-pages does not check out; it only needs to mint an OIDC token
+    # and write to Pages.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -25,9 +25,11 @@ jobs:
       run:
         working-directory: platform
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # Astro requires Node >=22.12.0 (astro check/build abort on Node 20).
           node-version: '22'
@@ -92,18 +94,26 @@ jobs:
       run:
         working-directory: platform
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # zizmor flags cache-poisoning here because this job publishes to Cloudflare.
+      # It is not reachable in practice: this job runs ONLY on push to main (see
+      # the `if:` above), never on a fork PR -- and a fork PR cannot write the base
+      # repo's Actions cache, so the npm cache restored here cannot be poisoned by
+      # an untrusted run. Suppressed with justification (the ignore sits on the
+      # `cache:` line to keep the `# v6.4.0` pin comment intact for Dependabot).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
-          cache: npm
+          cache: npm  # zizmor: ignore[cache-poisoning]
           cache-dependency-path: platform/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Build (astro build)
         run: npm run build --workspace=@embody/web
       - name: Deploy to Cloudflare (wrangler deploy)
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: Actions Security
+
+# Static analysis of the GitHub Actions workflows themselves (zizmor). Runs on
+# every PR and on pushes to main so misconfigurations (unpinned actions, leaked
+# credentials, injection, over-broad permissions) are caught before they ship.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+# Least-privilege default: grant nothing at the top level, widen per job.
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # checkout
+      security-events: write  # upload SARIF to the Security tab (public repo -> free)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7


### PR DESCRIPTION
Follow-up to #34 — hardens and automates the GitHub Actions supply chain.

## What
- **SHA-pin every action** to a full commit SHA with a `# vX.Y.Z` comment (closes the floating-tag exposure zizmor's `unpinned-uses` flags). Covers `checkout` v7.0.0, `setup-python` v6.3.0, `setup-node` v6.4.0, `upload-pages-artifact` v5.0.0, `deploy-pages` v5.0.0, `wrangler-action` v4.0.0.
- **zizmor security gate** (`.github/workflows/zizmor.yml`): static analysis of the workflows on every PR + push to main, uploading SARIF to the Security tab (free on this public repo).
- **Dependabot** (`.github/dependabot.yml`): weekly grouped updates for `github-actions` (bumps the SHA **and** its version comment together) and the `platform` npm workspace (minor/patch grouped, majors isolated for review).
- **Least privilege**: `docs.yml` permissions scoped per job (build reads; deploy writes Pages + OIDC only); `persist-credentials: false` on every checkout (fixes zizmor `artipacked`).

## Verification
Ran `zizmor v1.26.1` locally over all three workflows: **no findings (regular persona)**. One `cache-poisoning` finding on the deploy job is suppressed inline with justification — it's unreachable (deploy runs only on push to `main`; a fork PR cannot write the base repo's Actions cache). The ignore sits on the `cache:` line so the `# v6.4.0` pin comment stays intact for Dependabot.

## Note for the reviewer
`docs.yml`'s per-job permission scoping only executes on the next **push to main** (it has no PR trigger), so it can't be exercised by this PR's checks. It matches GitHub's documented Pages permission requirements (build: `contents: read`; deploy: `pages: write` + `id-token: write`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)