### PR TITLE
Simplify base test case

### DIFF
--- a/dev/embody/unit_tests/TestRunnerExt.py
+++ b/dev/embody/unit_tests/TestRunnerExt.py
@@ -18,22 +18,14 @@ from __future__ import annotations
 
 import time
 from collections import deque
-
-
-# =============================================================================
-# SKIP TEST EXCEPTION
-# =============================================================================
-
-class SkipTest(Exception):
-    """Raise inside a test method to skip it."""
-    pass
+from unittest import SkipTest, TestCase
 
 
 # =============================================================================
 # BASE TEST CASE
 # =============================================================================
 
-class EmbodyTestCase:
+class EmbodyTestCase(TestCase):
     """
     Base class for all Embody test suites.
 
@@ -42,6 +34,7 @@ class EmbodyTestCase:
     """
 
     def __init__(self, sandbox, embody, runner):
+        super().__init__()
         self.sandbox = sandbox          # baseCOMP to create temp operators in
         self.embody = embody            # op.Embody reference (the Embody COMP)
         self.runner = runner            # TestRunner instance
@@ -57,82 +50,14 @@ class EmbodyTestCase:
         """
         return self.embody.ext.Embody
 
-    def setUp(self):
-        """Called before each test method. Override for per-test setup."""
-        pass
-
     def tearDown(self):
-        """Called after each test method. Destroys all sandbox children."""
-        for child in list(self.sandbox.children):
-            try:
-                child.destroy()
-            except Exception:
-                pass
+        if self.sandbox is not None:
+            for child in list(self.sandbox.children):
+                try:
+                    child.destroy()
+                except Exception:
+                    pass
 
-    # -----------------------------------------------------------------
-    # Assertion helpers
-    # -----------------------------------------------------------------
-
-    def assertEqual(self, a, b, msg=None):
-        if a != b:
-            raise AssertionError(msg or f'Expected {repr(a)} == {repr(b)}')
-
-    def assertNotEqual(self, a, b, msg=None):
-        if a == b:
-            raise AssertionError(msg or f'Expected {repr(a)} != {repr(b)}')
-
-    def assertTrue(self, val, msg=None):
-        if not val:
-            raise AssertionError(msg or f'Expected truthy, got {repr(val)}')
-
-    def assertFalse(self, val, msg=None):
-        if val:
-            raise AssertionError(msg or f'Expected falsy, got {repr(val)}')
-
-    def assertIsNone(self, val, msg=None):
-        if val is not None:
-            raise AssertionError(msg or f'Expected None, got {repr(val)}')
-
-    def assertIsNotNone(self, val, msg=None):
-        if val is None:
-            raise AssertionError(msg or 'Expected not None')
-
-    def assertIs(self, a, b, msg=None):
-        if a is not b:
-            raise AssertionError(msg or f'Expected {repr(a)} is {repr(b)}')
-
-    def assertIsNot(self, a, b, msg=None):
-        if a is b:
-            raise AssertionError(msg or f'Expected {repr(a)} is not {repr(b)}')
-
-    def assertIn(self, item, container, msg=None):
-        if item not in container:
-            raise AssertionError(msg or f'{repr(item)} not in {repr(container)}')
-
-    def assertNotIn(self, item, container, msg=None):
-        if item in container:
-            raise AssertionError(msg or f'{repr(item)} unexpectedly in {repr(container)}')
-
-    def assertIsInstance(self, obj, cls, msg=None):
-        if not isinstance(obj, cls):
-            raise AssertionError(
-                msg or f'Expected instance of {cls.__name__}, got {type(obj).__name__}')
-
-    def assertGreater(self, a, b, msg=None):
-        if not (a > b):
-            raise AssertionError(msg or f'Expected {repr(a)} > {repr(b)}')
-
-    def assertGreaterEqual(self, a, b, msg=None):
-        if not (a >= b):
-            raise AssertionError(msg or f'Expected {repr(a)} >= {repr(b)}')
-
-    def assertLess(self, a, b, msg=None):
-        if not (a < b):
-            raise AssertionError(msg or f'Expected {repr(a)} < {repr(b)}')
-
-    def assertLessEqual(self, a, b, msg=None):
-        if not (a <= b):
-            raise AssertionError(msg or f'Expected {repr(a)} <= {repr(b)}')
 
     def assertStartsWith(self, s, prefix, msg=None):
         if not str(s).startswith(prefix):
@@ -142,16 +67,6 @@ class EmbodyTestCase:
         if not str(s).endswith(suffix):
             raise AssertionError(msg or f'{repr(s)} does not end with {repr(suffix)}')
 
-    def assertAlmostEqual(self, first, second, places=7, msg=None, delta=None):
-        if delta is not None:
-            if abs(first - second) > delta:
-                raise AssertionError(
-                    msg or f'{first} != {second} within delta {delta}')
-        else:
-            if round(abs(first - second), places) != 0:
-                raise AssertionError(
-                    msg or f'{first} != {second} within {places} places')
-
     def assertApproxEqual(self, a, b, tolerance=1e-6, msg=None):
         if abs(a - b) > tolerance:
             raise AssertionError(msg or f'{a} != {b} (tolerance {tolerance})')
@@ -160,24 +75,6 @@ class EmbodyTestCase:
         if key not in d:
             raise AssertionError(msg or f'Key {repr(key)} not in dict')
 
-    def assertDictEqual(self, a, b, msg=None):
-        if a != b:
-            raise AssertionError(msg or f'Dicts differ:\n  {repr(a)}\n  vs\n  {repr(b)}')
-
-    def assertListEqual(self, a, b, msg=None):
-        if list(a) != list(b):
-            raise AssertionError(msg or f'Lists differ:\n  {repr(list(a))}\n  vs\n  {repr(list(b))}')
-
-    def assertRaises(self, exc_type, fn, *args, **kwargs):
-        try:
-            fn(*args, **kwargs)
-        except exc_type:
-            return
-        except Exception as e:
-            raise AssertionError(
-                f'Expected {exc_type.__name__}, got {type(e).__name__}: {e}')
-        raise AssertionError(f'Expected {exc_type.__name__} but no exception raised')
-
     def assertLen(self, container, expected_len, msg=None):
         actual = len(container)
         if actual != expected_len:
@@ -185,7 +82,8 @@ class EmbodyTestCase:
                 msg or f'Expected length {expected_len}, got {actual}')
 
     def skip(self, reason=''):
-        raise SkipTest(reason)
+        """Historical alias for unittest.TestCase.skipTest."""
+        self.skipTest(reason)
 
 
 # =============================================================================

--- a/dev/embody/unit_tests/TestRunnerExt.py
+++ b/dev/embody/unit_tests/TestRunnerExt.py
@@ -81,10 +81,6 @@ class EmbodyTestCase(TestCase):
             raise AssertionError(
                 msg or f'Expected length {expected_len}, got {actual}')
 
-    def skip(self, reason=''):
-        """Historical alias for unittest.TestCase.skipTest."""
-        self.skipTest(reason)
-
 
 # =============================================================================
 # TEST RUNNER EXTENSION

--- a/dev/embody/unit_tests/TestRunnerExt.py
+++ b/dev/embody/unit_tests/TestRunnerExt.py
@@ -67,9 +67,6 @@ class EmbodyTestCase(TestCase):
         if not str(s).endswith(suffix):
             raise AssertionError(msg or f'{repr(s)} does not end with {repr(suffix)}')
 
-    def assertApproxEqual(self, a, b, tolerance=1e-6, msg=None):
-        self.assertAlmostEqual(a, b, delta=tolerance, msg=msg)
-
     def assertDictHasKey(self, d, key, msg=None):
         if key not in d:
             raise AssertionError(msg or f'Key {repr(key)} not in dict')

--- a/dev/embody/unit_tests/TestRunnerExt.py
+++ b/dev/embody/unit_tests/TestRunnerExt.py
@@ -68,8 +68,7 @@ class EmbodyTestCase(TestCase):
             raise AssertionError(msg or f'{repr(s)} does not end with {repr(suffix)}')
 
     def assertApproxEqual(self, a, b, tolerance=1e-6, msg=None):
-        if abs(a - b) > tolerance:
-            raise AssertionError(msg or f'{a} != {b} (tolerance {tolerance})')
+        self.assertAlmostEqual(a, b, delta=tolerance, msg=msg)
 
     def assertDictHasKey(self, d, key, msg=None):
         if key not in d:

--- a/dev/embody/unit_tests/test_custom_parameters.py
+++ b/dev/embody/unit_tests/test_custom_parameters.py
@@ -410,7 +410,7 @@ class TestCustomParameters(EmbodyTestCase):
             # is reported by the resilience layer until bind is reconfirmed).
             if any(s in status for s in ('Waiting', 'Starting', 'Stopping',
                                          'Restarting', 'reinit')):
-                self.skip(f'Server in transitional state: {status}')
+                self.skipTest(f'Server in transitional state: {status}')
             self.assertIn('Running', status)
         else:
             # Server not running - just verify the par exists
@@ -430,7 +430,7 @@ class TestCustomParameters(EmbodyTestCase):
         """Verbose controls whether DEBUG messages go to FIFO."""
         fifo = self.embody_ext._fifo
         if not fifo:
-            self.skip('FIFO DAT not available')
+            self.skipTest('FIFO DAT not available')
 
         # With Verbose OFF, Debug should NOT go to FIFO
         parexec = self.embody.op('parexec')

--- a/dev/embody/unit_tests/test_dat_restoration.py
+++ b/dev/embody/unit_tests/test_dat_restoration.py
@@ -128,9 +128,9 @@ class TestDATRestoration(EmbodyTestCase):
         expected_r = self.embody.par.Dattagcolorr.eval()
         expected_g = self.embody.par.Dattagcolorg.eval()
         expected_b = self.embody.par.Dattagcolorb.eval()
-        self.assertApproxEqual(restored.color[0], expected_r)
-        self.assertApproxEqual(restored.color[1], expected_g)
-        self.assertApproxEqual(restored.color[2], expected_b)
+        self.assertAlmostEqual(restored.color[0], expected_r)
+        self.assertAlmostEqual(restored.color[1], expected_g)
+        self.assertAlmostEqual(restored.color[2], expected_b)
 
     # =================================================================
     # RestoreDATs - skip conditions

--- a/dev/embody/unit_tests/test_duplicate_handling.py
+++ b/dev/embody/unit_tests/test_duplicate_handling.py
@@ -29,7 +29,7 @@ class TestDuplicateHandling(EmbodyTestCase):
         # Get any existing externalized op path
         table = self.embody_ext.Externalizations
         if not table or table.numRows <= 1:
-            self.skip('No externalizations to check')
+            self.skipTest('No externalizations to check')
         existing_path = table[1, 'path'].val
         result = self.embody_ext.cleanupDuplicateRows(existing_path)
         # Should return 0 (no duplicates to clean) or None
@@ -41,7 +41,7 @@ class TestDuplicateHandling(EmbodyTestCase):
     def test_cleanup_preserves_table_row_count(self):
         table = self.embody_ext.Externalizations
         if not table:
-            self.skip('No externalizations table')
+            self.skipTest('No externalizations table')
         initial_rows = table.numRows
         self.embody_ext.cleanupAllDuplicateRows()
         # Row count should be same or less (never more)
@@ -207,7 +207,7 @@ class TestReplicantHandling(EmbodyTestCase):
         # Filter to only actual replicants (not the table DAT)
         replicants = [c for c in replicants if self.embody_ext.isReplicant(c)]
         if not replicants:
-            self.skip('Replicator did not produce replicants (timing?)')
+            self.skipTest('Replicator did not produce replicants (timing?)')
 
         result = self.embody_ext._buildPathGroups()
         # None of the replicants should appear in the groups

--- a/dev/embody/unit_tests/test_envoy_bridge.py
+++ b/dev/embody/unit_tests/test_envoy_bridge.py
@@ -452,11 +452,11 @@ class TestBridgeWaitForEnvoy(EmbodyTestCase):
         # Should have retried using all RETRY_INTERVALS entries
         self.assertGreater(len(sleeps), 0, 'Should have retried at least once')
         # First sleep should match RETRY_INTERVALS[0]
-        self.assertApproxEqual(sleeps[0], bridge.RETRY_INTERVALS[0], tolerance=0.01)
+        self.assertAlmostEqual(sleeps[0], bridge.RETRY_INTERVALS[0], delta=0.01)
         # Verify several intervals match the schedule
         for i, expected in enumerate(bridge.RETRY_INTERVALS):
             if i < len(sleeps):
-                self.assertApproxEqual(sleeps[i], expected, tolerance=0.01)
+                self.assertAlmostEqual(sleeps[i], expected, delta=0.01)
 
     def test_retry_clamps_sleep_to_remaining_time(self):
         """Sleep duration is clamped to time remaining before deadline."""
@@ -514,8 +514,8 @@ class TestBridgeWaitForEnvoy(EmbodyTestCase):
         # Past the end of RETRY_INTERVALS, sleeps should cap at the last value
         self.assertGreater(len(sleeps), len(bridge.RETRY_INTERVALS))
         tail_sleep = sleeps[len(bridge.RETRY_INTERVALS)]
-        self.assertApproxEqual(
-            tail_sleep, bridge.RETRY_INTERVALS[-1], tolerance=0.01)
+        self.assertAlmostEqual(
+            tail_sleep, bridge.RETRY_INTERVALS[-1], delta=0.01)
 
 
 # =====================================================================

--- a/dev/embody/unit_tests/test_envoy_tool_guards.py
+++ b/dev/embody/unit_tests/test_envoy_tool_guards.py
@@ -126,7 +126,7 @@ class TestEnvoyToolGuards(EmbodyTestCase):
     def test_create_op_dispatch_is_undoable(self):
         undo = getattr(ui, 'undo', None)
         if undo is None or not hasattr(undo, 'undo'):
-            self.skip('ui.undo is not available in this harness')
+            self.skipTest('ui.undo is not available in this harness')
 
         name = self._unique('undo_text')
         result = op.Embody.ext.Envoy._execute_operation('create_op', {
@@ -141,22 +141,22 @@ class TestEnvoyToolGuards(EmbodyTestCase):
         try:
             undo.undo()
         except Exception as e:
-            self.skip('ui.undo.undo failed in this harness: {}'.format(e))
+            self.skipTest('ui.undo.undo failed in this harness: {}'.format(e))
 
         if op(created_path) is not None:
-            self.skip('ui.undo did not remove the Envoy-created op')
+            self.skipTest('ui.undo did not remove the Envoy-created op')
 
         if not hasattr(undo, 'redo'):
-            self.skip('ui.undo.redo is not available in this harness')
+            self.skipTest('ui.undo.redo is not available in this harness')
         try:
             undo.redo()
         except Exception as e:
-            self.skip('ui.undo.redo failed in this harness: {}'.format(e))
+            self.skipTest('ui.undo.redo failed in this harness: {}'.format(e))
         self.assertIsNotNone(op(created_path))
         try:
             undo.undo()
         except Exception as e:
-            self.skip('ui.undo final undo failed in this harness: {}'.format(e))
+            self.skipTest('ui.undo final undo failed in this harness: {}'.format(e))
         self.assertIsNone(op(created_path))
 
     def test_first_peer_advisory_carries_etiquette_hint_once(self):
@@ -225,13 +225,13 @@ class TestEnvoyToolGuards(EmbodyTestCase):
                 self.assertIn(name, result['error'])
                 self.assertEqual(par.eval(), before)
                 return
-        self.skip('noiseTOP type menu labels match menuNames in this TD build')
+        self.skipTest('noiseTOP type menu labels match menuNames in this TD build')
 
     def test_valid_menu_name_still_sets_value(self):
         noise = self.sandbox.create(noiseTOP, 'menu_valid_noise')
         menu_names = list(noise.par.type.menuNames)
         if not menu_names:
-            self.skip('noiseTOP type has no menuNames in this TD build')
+            self.skipTest('noiseTOP type has no menuNames in this TD build')
         value = menu_names[-1]
 
         result = op.Embody.ext.Envoy._set_parameter(
@@ -243,7 +243,7 @@ class TestEnvoyToolGuards(EmbodyTestCase):
     def test_strmenu_value_is_not_menu_guard_rejected(self):
         target, par = self._find_strmenu_parameter()
         if target is None:
-            self.skip('No writable StrMenu parameter found in this TD build')
+            self.skipTest('No writable StrMenu parameter found in this TD build')
 
         value = 'not_a_registered_strmenu_choice'
         result = op.Embody.ext.Envoy._set_parameter(
@@ -391,7 +391,7 @@ class TestEnvoyToolGuards(EmbodyTestCase):
     def test_get_parameter_compact_and_details_modes(self):
         noise = self.sandbox.create(noiseTOP, 'compact_get_parameter')
         if not getattr(noise.par.type, 'isMenu', False):
-            self.skip('noiseTOP type is not a Menu parameter in this TD build')
+            self.skipTest('noiseTOP type is not a Menu parameter in this TD build')
 
         compact = op.Embody.ext.Envoy._get_parameter(
             noise.path, par_name='type')
@@ -484,7 +484,7 @@ class TestCaptureTopSampleGrid(EmbodyTestCase):
     def _set_constant_color(self, top, r, g, b, a):
         for par_name in ('colorr', 'colorg', 'colorb', 'alpha'):
             if not hasattr(top.par, par_name):
-                self.skip('constantTOP missing {} parameter'.format(par_name))
+                self.skipTest('constantTOP missing {} parameter'.format(par_name))
         top.par.colorr = r
         top.par.colorg = g
         top.par.colorb = b
@@ -493,7 +493,7 @@ class TestCaptureTopSampleGrid(EmbodyTestCase):
     def _set_top_resolution(self, top, width, height):
         for par_name in ('outputresolution', 'resolutionw', 'resolutionh'):
             if not hasattr(top.par, par_name):
-                self.skip('TOP missing {} parameter'.format(par_name))
+                self.skipTest('TOP missing {} parameter'.format(par_name))
         top.par.outputresolution = 'custom'
         top.par.resolutionw = width
         top.par.resolutionh = height
@@ -522,7 +522,7 @@ class TestCaptureTopSampleGrid(EmbodyTestCase):
         try:
             top = self.sandbox.create(rampTOP, 'grid_ramp')
         except Exception:
-            self.skip('rampTOP not available')
+            self.skipTest('rampTOP not available')
             return
 
         result = op.Embody.ext.Envoy._capture_top(top.path, sample_grid=4)

--- a/dev/embody/unit_tests/test_layout_lint.py
+++ b/dev/embody/unit_tests/test_layout_lint.py
@@ -144,9 +144,9 @@ class TestLayoutLint(EmbodyTestCase):
         try:
             dat.dock = host
         except Exception as e:
-            self.skip(f'cannot set .dock in this TD build: {e}')
+            self.skipTest(f'cannot set .dock in this TD build: {e}')
         if dat.path not in [d.path for d in host.docked]:
-            self.skip('docking did not register dat in host.docked')
+            self.skipTest('docking did not register dat in host.docked')
 
     def test_scattered_docked_dat_reports_scattered(self):
         """A docked DAT forced > 350u from its host -> a 'scattered' issue."""
@@ -299,7 +299,7 @@ class TestLayoutLint(EmbodyTestCase):
         h = self.sandbox.op('ep_hug_host')
         d = self.sandbox.op('ep_hug_dock')
         if d.path not in [x.path for x in h.docked]:
-            self.skip('docking did not register in this TD build')
+            self.skipTest('docking did not register in this TD build')
         self.assertEqual(d.nodeY, h.nodeY - d.nodeHeight - 30,
                          f'scattered new dock must be auto-hugged, got nodeY={d.nodeY}')
         hug_msgs = [m for m in self._warnings() if 'auto-hugged' in m]

--- a/dev/embody/unit_tests/test_mcp_annotations.py
+++ b/dev/embody/unit_tests/test_mcp_annotations.py
@@ -108,7 +108,7 @@ class TestMCPAnnotations(EmbodyTestCase):
         )
         self.assertTrue(result.get('success'))
         ann = op(result['path'])
-        self.assertApproxEqual(ann.par.Backcolorr.eval(), 0.8, tolerance=0.01)
+        self.assertAlmostEqual(ann.par.Backcolorr.eval(), 0.8, delta=0.01)
 
     # =========================================================================
     # _create_annotation - errors

--- a/dev/embody/unit_tests/test_mcp_parameters.py
+++ b/dev/embody/unit_tests/test_mcp_parameters.py
@@ -26,7 +26,7 @@ class TestMCPParameters(EmbodyTestCase):
         comp = self.sandbox.create(geometryCOMP, 'par_verify')
         self.envoy._set_parameter(
             op_path=comp.path, par_name='tx', value='10')
-        self.assertApproxEqual(comp.par.tx.eval(), 10.0)
+        self.assertAlmostEqual(comp.par.tx.eval(), 10.0)
 
     # --- _set_parameter (expression) ---
 

--- a/dev/embody/unit_tests/test_smoke_release.py
+++ b/dev/embody/unit_tests/test_smoke_release.py
@@ -657,9 +657,9 @@ class TestSmokeRelease(EmbodyTestCase):
         speed = getattr(rf.par, 'Speed', None)
         self.assertIsNotNone(speed,
             'Custom Float parameter Speed was lost on import')
-        self.assertApproxEqual(speed.default, 2.5,
+        self.assertAlmostEqual(speed.default, 2.5,
             msg='Custom Float default value was not preserved')
-        self.assertApproxEqual(speed.eval(), 2.5,
+        self.assertAlmostEqual(speed.eval(), 2.5,
             msg='Custom Float live value (== default) was not preserved')
 
         # (3) Nested excluded COMP round-tripped with its exclude tag.

--- a/dev/embody/unit_tests/test_smoke_release.py
+++ b/dev/embody/unit_tests/test_smoke_release.py
@@ -256,7 +256,7 @@ class TestSmokeRelease(EmbodyTestCase):
     def test_envoy_server_running_if_enabled(self):
         """If Envoyenable is True, the MCP server should be running."""
         if not self.embody.par.Envoyenable.eval():
-            self.skip('Envoy not enabled in this session')
+            self.skipTest('Envoy not enabled in this session')
         # Check status parameter (survives extension reinit) rather than
         # envoy_running store (reset to False on every __init__).
         status = str(self.embody.par.Envoystatus.eval())
@@ -421,7 +421,7 @@ class TestSmokeRelease(EmbodyTestCase):
         """Collection sub-COMP has scanner + safe_import DATs and CollectionExt."""
         collection = self.embody.op('Collection')
         if collection is None:
-            self.skip('Collection sub-COMP not present on the release .tox')
+            self.skipTest('Collection sub-COMP not present on the release .tox')
         self.assertIsNotNone(collection.op('scanner'),
             'Collection/scanner DAT must exist')
         self.assertIsNotNone(collection.op('safe_import'),
@@ -523,9 +523,9 @@ class TestSmokeRelease(EmbodyTestCase):
         """A glsl-language textDAT externalizes with the glsl tag to a .glsl file."""
         envoy = self.embody.ext.Envoy
         if envoy is None:
-            self.skip('Envoy extension not loaded on the release .tox')
+            self.skipTest('Envoy extension not loaded on the release .tox')
         if not hasattr(envoy, '_externalize_op'):
-            self.skip('Envoy._externalize_op not available on this .tox')
+            self.skipTest('Envoy._externalize_op not available on this .tox')
 
         glsl_tag = self.embody.par.Glsltag.eval()
         dat = self._make_sandbox_comp('v6_glsl_host').create(textDAT, 'shader')
@@ -565,7 +565,7 @@ class TestSmokeRelease(EmbodyTestCase):
         """The watchdog tick / revive / probe methods exist on the Envoy ext."""
         envoy = self.embody.ext.Envoy
         if envoy is None:
-            self.skip('Envoy extension not loaded on the release .tox')
+            self.skipTest('Envoy extension not loaded on the release .tox')
         for name in ('_watchdogTick', '_reviveDeadServer', '_probeAlive'):
             method = getattr(envoy, name, None)
             self.assertIsNotNone(method,
@@ -581,7 +581,7 @@ class TestSmokeRelease(EmbodyTestCase):
         instance armed its self-healing loop on init.
         """
         if self.embody.ext.Envoy is None:
-            self.skip('Envoy extension not loaded on the release .tox')
+            self.skipTest('Envoy extension not loaded on the release .tox')
         gen = self.embody.fetch('_watchdog_gen', 0)
         self.assertGreater(int(gen), 0,
             'Envoy watchdog generation must be > 0 (no loop was armed)')
@@ -612,7 +612,7 @@ class TestSmokeRelease(EmbodyTestCase):
             xform = src.create(transformPOP, 'pop_transform')
             grid.outputConnectors[0].connect(xform.inputConnectors[0])
         except Exception:
-            self.skip('POPs not available in this TD build')
+            self.skipTest('POPs not available in this TD build')
             return
 
         # (2) A custom Float left at its (non-zero) default value. The default

--- a/dev/embody/unit_tests/test_specimen_publish.py
+++ b/dev/embody/unit_tests/test_specimen_publish.py
@@ -132,7 +132,7 @@ class TestSpecimenPublishBuckets(EmbodyTestCase):
 		super().setUp()
 		self.pub_op = op('/specimen_publish')
 		if self.pub_op is None:
-			self.skip('/specimen_publish DAT not present in this project')
+			self.skipTest('/specimen_publish DAT not present in this project')
 		self.mod = self.pub_op.module
 		# Snapshot the module globals we override so tearDown restores them.
 		self._saved_globals = {}
@@ -328,10 +328,10 @@ class TestSpecimenPublishLive(EmbodyTestCase):
 		super().setUp()
 		self.pub_op = op('/specimen_publish')
 		if self.pub_op is None:
-			self.skip('/specimen_publish DAT not present')
+			self.skipTest('/specimen_publish DAT not present')
 		lab = op('/specimen_lab')
 		if lab is None or not list(lab.children):
-			self.skip('/specimen_lab gallery not present (live-only test)')
+			self.skipTest('/specimen_lab gallery not present (live-only test)')
 		# Pick the first child COMP as the live specimen to publish.
 		self._live = None
 		for ch in lab.children:
@@ -339,7 +339,7 @@ class TestSpecimenPublishLive(EmbodyTestCase):
 				self._live = ch
 				break
 		if self._live is None:
-			self.skip('/specimen_lab has no COMP children')
+			self.skipTest('/specimen_lab has no COMP children')
 		self._tmp_out = tempfile.mkdtemp(prefix='specpub_live_')
 
 	def tearDown(self):

--- a/dev/embody/unit_tests/test_tdn_file_io.py
+++ b/dev/embody/unit_tests/test_tdn_file_io.py
@@ -711,9 +711,9 @@ class TestTDNFileIO(EmbodyTestCase):
 			data = yaml.safe_load(f)
 		entry = [o for o in data['operators'] if o['name'] == 'colored'][0]
 		self.assertIn('color', entry)
-		self.assertApproxEqual(entry['color'][0], 1.0)
-		self.assertApproxEqual(entry['color'][1], 0.0)
-		self.assertApproxEqual(entry['color'][2], 0.0)
+		self.assertAlmostEqual(entry['color'][0], 1.0)
+		self.assertAlmostEqual(entry['color'][1], 0.0)
+		self.assertAlmostEqual(entry['color'][2], 0.0)
 
 	def test_export_file_preserves_tags(self):
 		"""Operator tags should be in the exported file."""

--- a/dev/embody/unit_tests/test_tdn_helpers.py
+++ b/dev/embody/unit_tests/test_tdn_helpers.py
@@ -37,7 +37,7 @@ class TestTDNHelpers(EmbodyTestCase):
 
     def test_serializeValue_float_decimal_preserved(self):
         result = self.tdn._serializeValue(3.14)
-        self.assertApproxEqual(result, 3.14)
+        self.assertAlmostEqual(result, 3.14)
 
     def test_serializeValue_string_unchanged(self):
         self.assertEqual(self.tdn._serializeValue('hello'), 'hello')
@@ -144,7 +144,7 @@ class TestTDNHelpers(EmbodyTestCase):
 
     def test_serializeStorageValue_float(self):
         result = self.tdn._serializeStorageValue(3.14)
-        self.assertApproxEqual(result, 3.14)
+        self.assertAlmostEqual(result, 3.14)
 
     def test_serializeStorageValue_string(self):
         self.assertEqual(self.tdn._serializeStorageValue('hello'), 'hello')

--- a/dev/embody/unit_tests/test_tdn_reconstruction.py
+++ b/dev/embody/unit_tests/test_tdn_reconstruction.py
@@ -84,14 +84,14 @@ class TestTDNReconstruction(EmbodyTestCase):
 	def _assertParamEqual(self, val1, val2, msg=''):
 		"""Float-tolerant parameter comparison."""
 		if isinstance(val1, float) and isinstance(val2, float):
-			self.assertApproxEqual(val1, val2, msg=msg)
+			self.assertAlmostEqual(val1, val2, msg=msg)
 		elif isinstance(val1, str) and isinstance(val2, str):
 			self.assertEqual(val1, val2, msg)
 		else:
 			# Try numeric comparison
 			try:
 				f1, f2 = float(val1), float(val2)
-				self.assertApproxEqual(f1, f2, msg=msg)
+				self.assertAlmostEqual(f1, f2, msg=msg)
 			except (TypeError, ValueError):
 				self.assertEqual(val1, val2, msg)
 
@@ -192,7 +192,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 			if orig_color is not None:
 				self.assertIsNotNone(reimp_color, f'{name}: missing color')
 				for i in range(3):
-					self.assertApproxEqual(
+					self.assertAlmostEqual(
 						orig_color[i], reimp_color[i],
 						msg=f'{name}: color[{i}] mismatch')
 
@@ -637,10 +637,10 @@ class TestTDNReconstruction(EmbodyTestCase):
 		self._roundTrip(self.sandbox)
 		rc = self.sandbox.op('c')
 		self.assertIsNotNone(rc)
-		self.assertApproxEqual(rc.par.Speed.eval(), 3.14)
+		self.assertAlmostEqual(rc.par.Speed.eval(), 3.14)
 		self.assertTrue(rc.par.Speed.clampMin)
 		self.assertTrue(rc.par.Speed.clampMax)
-		self.assertApproxEqual(rc.par.Speed.max, 10.0)
+		self.assertAlmostEqual(rc.par.Speed.max, 10.0)
 
 	def test_C02_int_custom_par(self):
 		"""Int custom par round-trip."""
@@ -696,9 +696,9 @@ class TestTDNReconstruction(EmbodyTestCase):
 		c.par.Tintb = 0.2
 		self._roundTrip(self.sandbox)
 		rc = self.sandbox.op('c')
-		self.assertApproxEqual(rc.par.Tintr.eval(), 1.0)
-		self.assertApproxEqual(rc.par.Tintg.eval(), 0.5)
-		self.assertApproxEqual(rc.par.Tintb.eval(), 0.2)
+		self.assertAlmostEqual(rc.par.Tintr.eval(), 1.0)
+		self.assertAlmostEqual(rc.par.Tintg.eval(), 0.5)
+		self.assertAlmostEqual(rc.par.Tintb.eval(), 0.2)
 
 	def test_C07_xyz_custom_par(self):
 		"""XYZ (3-component) custom par round-trip."""
@@ -710,9 +710,9 @@ class TestTDNReconstruction(EmbodyTestCase):
 		c.par.Posz = 30.0
 		self._roundTrip(self.sandbox)
 		rc = self.sandbox.op('c')
-		self.assertApproxEqual(rc.par.Posx.eval(), 10.0)
-		self.assertApproxEqual(rc.par.Posy.eval(), 20.0)
-		self.assertApproxEqual(rc.par.Posz.eval(), 30.0)
+		self.assertAlmostEqual(rc.par.Posx.eval(), 10.0)
+		self.assertAlmostEqual(rc.par.Posy.eval(), 20.0)
+		self.assertAlmostEqual(rc.par.Posz.eval(), 30.0)
 
 	def test_C08_readonly_custom_par(self):
 		"""readOnly custom par round-trip."""
@@ -756,7 +756,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		c.par.Author = 'Test'
 		self._roundTrip(self.sandbox)
 		rc = self.sandbox.op('c')
-		self.assertApproxEqual(rc.par.Speed.eval(), 2.0)
+		self.assertAlmostEqual(rc.par.Speed.eval(), 2.0)
 		self.assertEqual(rc.par.Author.eval(), 'Test')
 
 	def test_C12_custom_par_expression_mode(self):
@@ -981,9 +981,9 @@ class TestTDNReconstruction(EmbodyTestCase):
 		n.color = (1.0, 0.0, 0.5)
 		self._roundTrip(self.sandbox)
 		rn = self.sandbox.op('n')
-		self.assertApproxEqual(rn.color[0], 1.0)
-		self.assertApproxEqual(rn.color[1], 0.0)
-		self.assertApproxEqual(rn.color[2], 0.5)
+		self.assertAlmostEqual(rn.color[0], 1.0)
+		self.assertAlmostEqual(rn.color[1], 0.0)
+		self.assertAlmostEqual(rn.color[2], 0.5)
 
 	def test_F05_comment(self):
 		"""Operator comment round-trip."""
@@ -1018,7 +1018,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		self.assertEqual(rn.nodeY, 200)
 		self.assertEqual(rn.nodeWidth, 180)
 		self.assertEqual(rn.nodeHeight, 120)
-		self.assertApproxEqual(rn.color[0], 0.5)
+		self.assertAlmostEqual(rn.color[0], 0.5)
 		self.assertEqual(rn.comment, 'Combined metadata test')
 		self.assertIn('test', rn.tags)
 
@@ -1218,7 +1218,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		for i in range(4):
 			rn = self.sandbox.op(f'n{i}')
 			self.assertEqual(int(rn.par.seed.eval()), 100)
-			self.assertApproxEqual(rn.par.amp.eval(), 0.5)
+			self.assertAlmostEqual(rn.par.amp.eval(), 0.5)
 
 	def test_I07_operator_override(self):
 		"""Individual op can override type_defaults value."""
@@ -1233,7 +1233,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		n3.par.amp = 0.5
 		self._roundTrip(self.sandbox)
 		rn2 = self.sandbox.op('n2')
-		self.assertApproxEqual(rn2.par.amp.eval(), 0.8)
+		self.assertAlmostEqual(rn2.par.amp.eval(), 0.8)
 
 	def test_I08_flags_hoisted_to_type_defaults(self):
 		"""Flags unanimously shared across ops of a type are hoisted."""
@@ -1323,9 +1323,9 @@ class TestTDNReconstruction(EmbodyTestCase):
 			self.assertTrue(rn.viewer)
 			self.assertEqual(rn.nodeWidth, 250)
 			self.assertEqual(rn.nodeHeight, 120)
-			self.assertApproxEqual(rn.color[0], 0.3)
-			self.assertApproxEqual(rn.color[1], 0.6)
-			self.assertApproxEqual(rn.color[2], 0.9)
+			self.assertAlmostEqual(rn.color[0], 0.3)
+			self.assertAlmostEqual(rn.color[1], 0.6)
+			self.assertAlmostEqual(rn.color[2], 0.9)
 			self.assertEqual(sorted(rn.tags), ['fx', 'test'])
 
 	def test_I14_partial_flags_not_hoisted(self):
@@ -1441,7 +1441,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		self._roundTrip(self.sandbox)
 		for i in range(3):
 			rc = self.sandbox.op(f'c{i}')
-			self.assertApproxEqual(rc.par.Speed.eval(), float(i))
+			self.assertAlmostEqual(rc.par.Speed.eval(), float(i))
 			expected_mode = 'b' if i % 2 else 'a'
 			self.assertEqual(rc.par.Mode.eval(), expected_mode)
 
@@ -1483,7 +1483,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		c.par.Speed = 3.14
 		self._simulateReconstruction(self.sandbox)
 		rc = self.sandbox.op('c')
-		self.assertApproxEqual(rc.par.Speed.eval(), 3.14)
+		self.assertAlmostEqual(rc.par.Speed.eval(), 3.14)
 
 	def test_K05_dat_content_through_reconstruction(self):
 		"""DAT content preserved through strip + reimport."""
@@ -1629,7 +1629,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		self.assertTrue(result.get('success'))
 
 		self.assertTrue(hasattr(self.sandbox.par, 'Threshold'))
-		self.assertApproxEqual(self.sandbox.par.Threshold.eval(), 0.75)
+		self.assertAlmostEqual(self.sandbox.par.Threshold.eval(), 0.75)
 
 	def test_K13_backward_compat_no_container_fields(self):
 		"""Import of TDN without top-level custom_pars/parameters must not error."""
@@ -2338,7 +2338,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		c.store('speed', 3.14)
 		self._roundTrip(self.sandbox)
 		result = self.sandbox.op('c').fetch('speed', None, search=False)
-		self.assertApproxEqual(result, 3.14)
+		self.assertAlmostEqual(result, 3.14)
 
 	def test_Q03_string_storage_roundtrip(self):
 		"""String storage value round-trips."""

--- a/dev/embody/unit_tests/test_tdn_reconstruction.py
+++ b/dev/embody/unit_tests/test_tdn_reconstruction.py
@@ -1958,7 +1958,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 			t = self.sandbox.create(transformPOP, 'pt')
 			g.outputConnectors[0].connect(t.inputConnectors[0])
 		except Exception:
-			self.skip('POPs not available in this TD version')
+			self.skipTest('POPs not available in this TD version')
 			return
 		self._roundTrip(self.sandbox)
 		rg = self.sandbox.op('pg')
@@ -1974,7 +1974,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(gridPOP, 'pop1')
 		except Exception:
-			self.skip('POPs not available in this TD version')
+			self.skipTest('POPs not available in this TD version')
 			return
 		self._roundTrip(self.sandbox)
 		self.assertIsNotNone(self.sandbox.op('top1'))
@@ -3452,12 +3452,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			g = self.sandbox.create(glslTOP, 'glsl1')
 		except Exception:
-			self.skip('glslTOP not available')
+			self.skipTest('glslTOP not available')
 			return
 
 		pixel_dat = self.sandbox.op('glsl1_pixel')
 		if pixel_dat is None:
-			self.skip('glslTOP did not create pixel companion')
+			self.skipTest('glslTOP did not create pixel companion')
 			return
 
 		pixel_dat.text = '// custom pixel shader\nvoid main() {}'
@@ -3473,12 +3473,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			g = self.sandbox.create(glslTOP, 'glsl1')
 		except Exception:
-			self.skip('glslTOP not available')
+			self.skipTest('glslTOP not available')
 			return
 
 		info_dat = self.sandbox.op('glsl1_info')
 		if info_dat is None:
-			self.skip('glslTOP did not create info companion')
+			self.skipTest('glslTOP did not create info companion')
 			return
 
 		orig = self.tdn.ExportNetwork(
@@ -3508,12 +3508,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			t = self.sandbox.create(timerCHOP, 'timer1')
 		except Exception:
-			self.skip('timerCHOP not available')
+			self.skipTest('timerCHOP not available')
 			return
 
 		cb_dat = self.sandbox.op('timer1_callbacks')
 		if cb_dat is None:
-			self.skip('timerCHOP did not create callbacks companion')
+			self.skipTest('timerCHOP did not create callbacks companion')
 			return
 
 		cb_dat.text = '# custom callbacks\ndef onStart():\n\tpass'
@@ -3530,12 +3530,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(timerCHOP, 'timer1')
 		except Exception:
-			self.skip('timerCHOP not available')
+			self.skipTest('timerCHOP not available')
 			return
 
 		cb_dat = self.sandbox.op('timer1_callbacks')
 		if cb_dat is None:
-			self.skip('timerCHOP did not create callbacks companion')
+			self.skipTest('timerCHOP did not create callbacks companion')
 			return
 
 		self._roundTrip(self.sandbox)
@@ -3552,12 +3552,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			g = self.sandbox.create(glslPOP, 'glsl1')
 		except Exception:
-			self.skip('glslPOP not available')
+			self.skipTest('glslPOP not available')
 			return
 
 		compute_dat = self.sandbox.op('glsl1_compute')
 		if compute_dat is None:
-			self.skip('glslPOP did not create compute companion')
+			self.skipTest('glslPOP did not create compute companion')
 			return
 
 		compute_dat.text = '// custom compute shader\nvoid main() {}'
@@ -3574,7 +3574,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(glslTOP, 'glsl1')
 		except Exception:
-			self.skip('glslTOP not available')
+			self.skipTest('glslTOP not available')
 			return
 
 		orig = self.tdn.ExportNetwork(
@@ -3592,12 +3592,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(glslmultiTOP, 'glsl1')
 		except Exception:
-			self.skip('glslmultiTOP not available')
+			self.skipTest('glslmultiTOP not available')
 			return
 
 		pixel_dat = self.sandbox.op('glsl1_pixel')
 		if pixel_dat is None:
-			self.skip('glslmultiTOP did not create pixel companion')
+			self.skipTest('glslmultiTOP did not create pixel companion')
 			return
 		pixel_dat.text = '// custom multi pixel\nvoid main() {}'
 
@@ -3620,12 +3620,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(glsladvancedPOP, 'glsl1')
 		except Exception:
-			self.skip('glsladvancedPOP not available')
+			self.skipTest('glsladvancedPOP not available')
 			return
 
 		compute_dat = self.sandbox.op('glsl1_compute')
 		if compute_dat is None:
-			self.skip('glsladvancedPOP did not create compute companion')
+			self.skipTest('glsladvancedPOP did not create compute companion')
 			return
 		compute_dat.text = '// custom advanced compute\nvoid main() {}'
 
@@ -3646,12 +3646,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(glslcopyPOP, 'glsl1')
 		except Exception:
-			self.skip('glslcopyPOP not available')
+			self.skipTest('glslcopyPOP not available')
 			return
 
 		pt_dat = self.sandbox.op('glsl1_ptCompute')
 		if pt_dat is None:
-			self.skip('glslcopyPOP did not create ptCompute companion')
+			self.skipTest('glslcopyPOP did not create ptCompute companion')
 			return
 		pt_dat.text = '// custom copy pt compute\nvoid main() {}'
 
@@ -3674,12 +3674,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(rampTOP, 'ramp1')
 		except Exception:
-			self.skip('rampTOP not available')
+			self.skipTest('rampTOP not available')
 			return
 
 		keys_dat = self.sandbox.op('ramp1_keys')
 		if keys_dat is None:
-			self.skip('rampTOP did not create keys companion')
+			self.skipTest('rampTOP did not create keys companion')
 			return
 
 		# Modify the keys table
@@ -3705,12 +3705,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(scriptCHOP, 'script1')
 		except Exception:
-			self.skip('scriptCHOP not available')
+			self.skipTest('scriptCHOP not available')
 			return
 
 		cb_dat = self.sandbox.op('script1_callbacks')
 		if cb_dat is None:
-			self.skip('scriptCHOP did not create callbacks companion')
+			self.skipTest('scriptCHOP did not create callbacks companion')
 			return
 		cb_dat.text = '# custom script chop callbacks'
 
@@ -3731,12 +3731,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(scriptSOP, 'script1')
 		except Exception:
-			self.skip('scriptSOP not available')
+			self.skipTest('scriptSOP not available')
 			return
 
 		cb_dat = self.sandbox.op('script1_callbacks')
 		if cb_dat is None:
-			self.skip('scriptSOP did not create callbacks companion')
+			self.skipTest('scriptSOP did not create callbacks companion')
 			return
 		cb_dat.text = '# custom script sop callbacks'
 
@@ -3757,12 +3757,12 @@ class TestTDNReconstruction(EmbodyTestCase):
 		try:
 			self.sandbox.create(scriptDAT, 'script1')
 		except Exception:
-			self.skip('scriptDAT not available')
+			self.skipTest('scriptDAT not available')
 			return
 
 		cb_dat = self.sandbox.op('script1_callbacks')
 		if cb_dat is None:
-			self.skip('scriptDAT did not create callbacks companion')
+			self.skipTest('scriptDAT did not create callbacks companion')
 			return
 		cb_dat.text = '# custom script dat callbacks'
 
@@ -3803,7 +3803,7 @@ class TestTDNReconstruction(EmbodyTestCase):
 				pass  # Skip unavailable types
 
 		if len(created) < 3:
-			self.skip('Too few companion-creating ops available')
+			self.skipTest('Too few companion-creating ops available')
 			return
 
 		# Snapshot companion names before round-trip

--- a/dev/embody/unit_tests/test_tdn_yaml.py
+++ b/dev/embody/unit_tests/test_tdn_yaml.py
@@ -73,7 +73,7 @@ class TestTDNYaml(EmbodyTestCase):
         loads back equal, and re-dumps byte-identical (determinism)."""
         root = _specimen_root()
         if root is None:
-            self.skip('specimens/ folder not found')
+            self.skipTest('specimens/ folder not found')
         names = [
             'generative/reaction-diffusion.tdn',
             'compositing/kaleidoscope.tdn',
@@ -95,7 +95,7 @@ class TestTDNYaml(EmbodyTestCase):
             self.assertEqual(self.tdn.tdn_dump(doc), dumped,
                 f'{rel}: re-dump not byte-identical')
         if checked == 0:
-            self.skip('no specimen files present')
+            self.skipTest('no specimen files present')
 
     # =================================================================
     # Block-scalar losslessness (headless, no TD)
@@ -369,9 +369,9 @@ class TestTDNYaml(EmbodyTestCase):
         and degrades to raw passthrough when yaml is unavailable."""
         mod = self._load_textconv()
         if mod is None:
-            self.skip('textconv template not found')
+            self.skipTest('textconv template not found')
         if not getattr(mod, '_HAVE_YAML', False):
-            self.skip('PyYAML unavailable in textconv module')
+            self.skipTest('PyYAML unavailable in textconv module')
 
         # Same network, two on-disk forms.
         v15 = {
@@ -450,9 +450,9 @@ class TestTDNYaml(EmbodyTestCase):
         glsl = self.sandbox.create(glslTOP, 'glsl_omit')
         compute = glsl.op(f'{glsl.name}_compute')
         if compute is None:
-            self.skip('glslTOP does not dock a <name>_compute DAT here')
+            self.skipTest('glslTOP does not dock a <name>_compute DAT here')
         if compute.dock is None or compute.dock.path != glsl.path:
-            self.skip('compute DAT is not docked to the glslTOP')
+            self.skipTest('compute DAT is not docked to the glslTOP')
 
         default_text = compute.text
 

--- a/dev/embody/unit_tests/test_update_sync.py
+++ b/dev/embody/unit_tests/test_update_sync.py
@@ -43,7 +43,7 @@ class TestUpdateSync(EmbodyTestCase):
     def test_externalizations_table_rows_have_valid_paths(self):
         table = self.embody_ext.Externalizations
         if not table or table.numRows <= 1:
-            self.skip('No externalizations to check')
+            self.skipTest('No externalizations to check')
         for i in range(1, table.numRows):
             path = table[i, 'path'].val
             self.assertTrue(path.startswith('/'),
@@ -52,7 +52,7 @@ class TestUpdateSync(EmbodyTestCase):
     def test_externalizations_table_rows_have_type(self):
         table = self.embody_ext.Externalizations
         if not table or table.numRows <= 1:
-            self.skip('No externalizations to check')
+            self.skipTest('No externalizations to check')
         for i in range(1, table.numRows):
             op_type = table[i, 'type'].val
             self.assertTrue(len(op_type) > 0,
@@ -61,7 +61,7 @@ class TestUpdateSync(EmbodyTestCase):
     def test_externalizations_table_rows_have_file_path(self):
         table = self.embody_ext.Externalizations
         if not table or table.numRows <= 1:
-            self.skip('No externalizations to check')
+            self.skipTest('No externalizations to check')
         for i in range(1, table.numRows):
             rel_path = table[i, 'rel_file_path'].val
             self.assertTrue(len(rel_path) > 0,
@@ -70,7 +70,7 @@ class TestUpdateSync(EmbodyTestCase):
     def test_externalizations_no_backslashes_in_paths(self):
         table = self.embody_ext.Externalizations
         if not table or table.numRows <= 1:
-            self.skip('No externalizations to check')
+            self.skipTest('No externalizations to check')
         for i in range(1, table.numRows):
             rel_path = table[i, 'rel_file_path'].val
             self.assertNotIn('\\', rel_path,

--- a/dev/embody/unit_tests/test_v6_hardening.py
+++ b/dev/embody/unit_tests/test_v6_hardening.py
@@ -188,7 +188,7 @@ class TestTDNBlockScalarFileIO(EmbodyTestCase):
         dat.text = 'line one\nline two\n\n'
         src_text = dat.text
         if not src_text.endswith('\n\n'):
-            self.skip('TD trimmed the second trailing newline on this build')
+            self.skipTest('TD trimmed the second trailing newline on this build')
 
         fp = str(Path(self._temp_dir) / 'two_nl.tdn')
         self._export_dat(dat, fp)
@@ -254,9 +254,9 @@ class TestTDNBoilerplateNegativeGuards(EmbodyTestCase):
         try:
             dat.dock = host
         except Exception as e:
-            self.skip(f'DAT docking not supported on this build: {e}')
+            self.skipTest(f'DAT docking not supported on this build: {e}')
         if dat.dock is None or dat.dock.path != host.path:
-            self.skip('dock assignment did not take effect')
+            self.skipTest('dock assignment did not take effect')
         # Name is 'wrongname', not 'myhost_compute' -> condition 2 fails.
         self.assertNotEqual(dat.name, f'{host.name}_compute',
             'precondition: name must differ from the companion pattern')
@@ -304,9 +304,9 @@ class TestTDNTextconvDegrade(EmbodyTestCase):
         still diffs (unfiltered) rather than breaking git."""
         mod = self._load_textconv()
         if mod is None:
-            self.skip('textconv template not found')
+            self.skipTest('textconv template not found')
         if not getattr(mod, '_HAVE_YAML', False):
-            self.skip('PyYAML unavailable in textconv module')
+            self.skipTest('PyYAML unavailable in textconv module')
 
         # Brace-prefixed, invalid as BOTH JSON and YAML -> _parse raises ->
         # normalize returns raw.
@@ -318,9 +318,9 @@ class TestTDNTextconvDegrade(EmbodyTestCase):
         """A non-brace, invalid-YAML blob also degrades to raw passthrough."""
         mod = self._load_textconv()
         if mod is None:
-            self.skip('textconv template not found')
+            self.skipTest('textconv template not found')
         if not getattr(mod, '_HAVE_YAML', False):
-            self.skip('PyYAML unavailable in textconv module')
+            self.skipTest('PyYAML unavailable in textconv module')
         blob = 'foo: |\n\tbad tab block\n'
         self.assertEqual(mod.normalize(blob), blob,
             'invalid-YAML blob must pass through normalize() unchanged')

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -169,9 +169,7 @@ run_tests(suite_name='test_path_utils')  # Run one suite
 ## Test Framework Features
 
 - **Sandbox isolation**: Each suite gets a fresh `baseCOMP` for test fixtures
-- **20+ assertion methods**: `assertEqual`, `assertTrue`, `assertIn`, `assertIsInstance`, etc.
-- **Lifecycle hooks**: `setUp`/`tearDown` per test, `setUpSuite`/`tearDownSuite` per suite
-- **Skip support**: `self.skip(reason)` to conditionally skip tests
+- **unittest-based**: Supports all assertions, lifecycle hooks and other features unittest supports
 - **Results tracking**: Table DAT with pass/fail/error/skip counts and durations
 
 ## Writing New Tests


### PR DESCRIPTION
Builds `EmbodyTestCase` on `unittest.TestCase` and cleans the redundant methods.