### PR TITLE
Docs site logo (Embody "e") + landing page padding fix

### DIFF
--- a/docs/assets/embody-logo.svg
+++ b/docs/assets/embody-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Embody">
+  <!-- Embody mark: a lowercase 'e' as an OK-hand pinch grasping a glowing orb -->
+  <circle cx="45" cy="45" r="4.7" fill="#c9f5c4"/>
+  <g fill="none" stroke="#6ee668" stroke-width="8.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 36.57 49.38 A 17 17 0 1 1 48.69 36.24"/>
+    <path d="M 16 33 L 47.5 33"/>
+  </g>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ repo_name: Embody
 
 theme:
   name: material
+  logo: assets/embody-logo.svg
+  favicon: assets/embody-mark.svg
   font:
     text: Open Sans
     code: Roboto Mono

--- a/platform/apps/web/src/styles/embody.css
+++ b/platform/apps/web/src/styles/embody.css
@@ -1618,6 +1618,7 @@ pre {
   display: flex;
   flex-direction: column;
   gap: 0;
+  margin: 0 -1.25rem;
   border-top: 1px solid var(--border-faint);
 }
 .practice__row {
@@ -1625,7 +1626,7 @@ pre {
   grid-template-columns: 1.3fr 1fr;
   gap: 2.5rem;
   align-items: baseline;
-  padding: 1.4rem 0;
+  padding: 1.4rem 1.25rem;
   border-bottom: 1px solid var(--border-faint);
   transition: background 160ms ease;
 }
@@ -1870,7 +1871,7 @@ body.is-app-shell .footer {
 /* Landing tablet reflow, aligned to the nav hamburger boundary (was 820). */
 @media (max-width: 860px) {
   .tdn__grid { grid-template-columns: 1fr; gap: 2rem; }
-  .practice__row { grid-template-columns: 1fr; gap: 0.5rem; padding: 1.2rem 0; }
+  .practice__row { grid-template-columns: 1fr; gap: 0.5rem; padding: 1.2rem 1.25rem; }
   .footer__inner { grid-template-columns: 1fr 1fr; gap: 2.5rem; }
   .footer__col--brand { grid-column: 1 / -1; }
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -482,6 +482,7 @@ code, kbd, pre {
   display: flex;
   flex-direction: column;
   gap: 0;
+  margin: 0 -1.25rem;
   border-top: 1px solid var(--border-faint);
 }
 .practice__row {
@@ -489,7 +490,7 @@ code, kbd, pre {
   grid-template-columns: 1.3fr 1fr;
   gap: 2.5rem;
   align-items: baseline;
-  padding: 1.4rem 0;
+  padding: 1.4rem 1.25rem;
   border-bottom: 1px solid var(--border-faint);
   transition: background 160ms ease;
 }
@@ -1055,7 +1056,7 @@ code, kbd, pre {
   .practice__row {
     grid-template-columns: 1fr;
     gap: 0.5rem;
-    padding: 1.2rem 0;
+    padding: 1.2rem 1.25rem;
   }
   .compare {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Two small, unrelated front-end fixes.

**Docs site logo** — MkDocs Material had no `logo`/`favicon` set, so the header showed the default document icon. Point the header logo at the transparent "e" glyph (reads cleanly on the always-dark header) and the favicon at the square "e" mark, matching the web app's browser-tab icon. Merging to `main` publishes it via the Pages workflow.

**Landing "In Practice" padding** — `.practice__row` had zero horizontal padding, so the hover highlight ran edge-to-edge and jammed the text against the left edge. Added 1.25rem horizontal padding + a matching `-1.25rem` list bleed so text stays aligned with the heading and dividers. Applied to both the Astro app (already deployed live to embody.tools) and the static `web/` mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)