### PR TITLE
Fix createExternalizationsTable infinite recursion (externalization pipeline dead without an existing tracking table)

### DIFF
--- a/dev/embody/Embody/EmbodyExt.py
+++ b/dev/embody/Embody/EmbodyExt.py
@@ -3000,13 +3000,21 @@ class EmbodyExt:
 
         self.my.par.Externalizations.val = externalizations_dat
 
-    def createExternalizationsTable(self) -> None:
+    def ensureExternalizationsTable(self) -> None:
         """Recovery/init method: create or reconnect the externalizations table.
 
         Safe to call at any time. No-op if the table already exists and is
         connected via par.Externalizations. If the parameter is empty but a
         sibling named 'externalizations' exists (e.g. after an Embody upgrade),
-        reconnects to it without creating a duplicate.
+        reconnects to it without creating a duplicate. Only when neither is
+        true does it fall through to createExternalizationsTable() to build a
+        fresh one -- so, unlike that method, it never clears an existing table.
+
+        Was previously also named createExternalizationsTable, which shadowed
+        the real creator above (last def wins); the fall-through then called
+        itself and recursed until RecursionError, so on a project with no
+        table the table was never built and every downstream consumer (the
+        continuity sweep, the tagger) crashed on a None DAT.
         """
         externalizations_dat = self.Externalizations
         if not externalizations_dat:
@@ -3235,7 +3243,7 @@ class EmbodyExt:
     def verify(self) -> None:
         """Initialize or reconnect Embody on install or update.
 
-        Called from execute.py onCreate() after createExternalizationsTable()
+        Called from execute.py onCreate() after ensureExternalizationsTable()
         has already run.  Two scenarios:
 
         - Fresh install: table exists but is empty (just created) -- skip dialog,
@@ -7100,14 +7108,25 @@ class EmbodyExt:
         """Check for renamed, moved, or missing operators and update accordingly."""
         self._checkExternalToxPar()
 
+        externalizations = self.Externalizations
+        if externalizations is None:
+            # par.Externalizations is unset or points at a missing DAT (fresh
+            # or recovered project before ensureExternalizationsTable() has
+            # rebuilt it). Nothing to reconcile -- degrade to a no-op instead
+            # of raising "'NoneType' object has no attribute 'numCols'" on
+            # every Update()/save.
+            self.Log("checkOpsForContinuity: no externalizations table -- "
+                     "skipping continuity sweep", "WARNING")
+            return
+
         try:
             rows_to_check = []
             tdn_comp_paths = set()
-            headers = [self._cellVal(0, c)
-                       for c in range(self.Externalizations.numCols)]
+            headers = [self._cellVal(0, c, table=externalizations)
+                       for c in range(externalizations.numCols)]
             has_strategy = 'strategy' in headers
             embody_root = self.my.path
-            for i in range(1, self.Externalizations.numRows):
+            for i in range(1, externalizations.numRows):
                 row_path = self._cellVal(i, 'path')
                 if row_path:
                     # HARD INVARIANT: the continuity sweep must NEVER touch

--- a/dev/embody/Embody/execute.py
+++ b/dev/embody/Embody/execute.py
@@ -120,8 +120,10 @@ def onCreate():
 	init()
 	# Same seed as onStart -- see there.
 	parent.Embody.ext.Embody.seedAutosaveStatus()
-	# Auto-create (or reconnect) the externalizations table before Verify()
-	run(f"op('{parent.Embody}').ext.Embody.createExternalizationsTable()", delayFrames=15)
+	# Auto-create (or reconnect) the externalizations table before Verify().
+	# ensure* is the non-destructive path: reconnect or build fresh, never
+	# clear an existing table (createExternalizationsTable resets).
+	run(f"op('{parent.Embody}').ext.Embody.ensureExternalizationsTable()", delayFrames=15)
 	# Verify handles update-scenario detection and Envoy opt-in
 	run(f"op('{parent.Embody}').ext.Embody.verify()", delayFrames=30)
 	# Ensure catalogs load on fresh-project drops too, not just onStart.

--- a/dev/embody/Embody/parexec.py
+++ b/dev/embody/Embody/parexec.py
@@ -382,7 +382,10 @@ def onPulse(par):
 		parent.Embody.ext.Embody.openTable()
 
 	elif par.name == 'Createexternalizationstable':
-		parent.Embody.ext.Embody.createExternalizationsTable()
+		# ensure, not create: the par's documented contract is "no-op if the
+		# table is already connected"; create* is the create-or-RESET variant
+		# and would clear the tracking rows on pulse (PR #95).
+		parent.Embody.ext.Embody.ensureExternalizationsTable()
 
 	elif par.name == 'Externalizeproject':
 		parent.Embody.ext.Embody.externalizeProject()


### PR DESCRIPTION
## Problem

`EmbodyExt` defines `createExternalizationsTable` **twice** (~L2964 and ~L3003).
Python keeps the second — a "create or reconnect" variant — which shadows the
real table-builder. Its final fall-through is `self.createExternalizationsTable()`,
i.e. it calls **itself**, recursing until `RecursionError`.

On any project without an already-connected `externalizations` table DAT (a
fresh project, or one where `par.Externalizations` was lost), the table is
therefore **never created**, and every consumer that assumes it exists crashes
on `None`:

- `checkOpsForContinuity` → `'NoneType' object has no attribute 'numCols'`
- the `envoy_ops` tagger → `Failed to tag: 'NoneType' object has no attribute 'path'`
- `Pre-save externalization failed (save will continue)`

These fire on **every `Update()` / every save**, and `externalize_op` fails 100%
of the time.

### Repro

1. New TD project, drag in the stock Embody `.tox`.
2. Create a `textDAT`.
3. `externalize_op` it (or just save the project).
4. Log shows the `checkOpsForContinuity` error; the tag/externalize fails.

`op.Embody.ext.Embody.createExternalizationsTable()` raises `RecursionError`
directly; `op.Embody.par.Externalizations.eval()` is `None`.

## Fix

- Rename the shadowing "create or reconnect" method to
  **`ensureExternalizationsTable`** (idempotent — never clears an existing
  table). Its fall-through now reaches the real, unshadowed
  `createExternalizationsTable`.
- Point `execute.py` `onCreate()` at `ensureExternalizationsTable` (the
  non-destructive path it always wanted). `parexec.py`'s "Create table" button
  and `embody_git.reset()` keep calling `createExternalizationsTable` — now the
  only method with that name, and working (create-or-reset).
- Null-guard `checkOpsForContinuity` so a missing/misconfigured table logs a
  warning and no-ops instead of raising on every sweep.

`def createExternalizationsTable` count goes 2 → 1. No test files reference
either method by name; both files parse.

## Verified

With both changes applied: `checkOpsForContinuity` runs clean,
`ensureExternalizationsTable()` builds the table with the correct 8-column
header, and `externalize_op` on a fresh `textDAT` succeeds end to end.