### PR TITLE
Fix embody.tools login: skip better-auth 1.7 schema check on D1

### DIFF
--- a/platform/apps/web/src/lib/auth.ts
+++ b/platform/apps/web/src/lib/auth.ts
@@ -74,7 +74,14 @@ function buildAuth(env: AuthEnv, secret: string) {
     // the inference falls through to false -> a session cookie with NO Secure
     // flag in production. Pin it to our own ENVIRONMENT var instead (which is
     // "development" only via .dev.vars for local http dev).
-    advanced: { useSecureCookies: env.ENVIRONMENT === "production" },
+    advanced: {
+      useSecureCookies: env.ENVIRONMENT === "production",
+      // better-auth 1.7 introspects the schema on first use; D1 refuses
+      // pragma_table_info on its internal _cf_METADATA table (SQLITE_AUTH),
+      // so every auth request returned 500 (field 2026-09-11). Migrations
+      // and the e2e suite guard the schema instead.
+      database: { validateSchema: false }
+    },
     database: {
       dialect: new D1Dialect({ database: env.DB }),
       type: "sqlite"


### PR DESCRIPTION
Login, sign-up and password reset on embody.tools have returned HTTP 500 on every request since the #105 deploy (2026-09-10 17:15 UTC).

**Cause:** #105 carried a Dependabot bump of better-auth from 1.6.23 to 1.7.3. Version 1.7 runs a schema check on first use, and Kysely's SQLite introspector calls `pragma_table_info` on every table. That includes D1's internal `_cf_METADATA` table, which D1 refuses with `SQLITE_AUTH`. Every auth request waits on the check, so all of them failed. The sign-in page reported the 500 as "invalid email or password."

**Fix:** set `advanced.database.validateSchema: false`, the opt-out documented by Better Auth. One file changed.

**Verified locally**, on a fresh D1 with the dev server and with the production build:
- sign-up, session with cookie, sign-in, sign-out, password reset: 200
- wrong password: 401 (was 500)
- `astro check`: 0 errors. `astro build`: OK.

**Follow-up PR:** run the Playwright e2e suite in CI as a required gate before deploy, add a smoke check against production after each deploy, and stop the auth pages from reporting server errors as bad credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
