### PR TITLE
Fix specimen submit and network edits: send the frozen tdn wire key

### DIFF
--- a/platform/apps/web/e2e/contribute.spec.ts
+++ b/platform/apps/web/e2e/contribute.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { fillTdxn } from "./editor";
 
 // The core write path: a signed-in user submits a Specimen. In dev,
@@ -37,6 +40,26 @@ test("signed-in user submits a specimen and lands on its page", async ({ page })
   // On success the client redirects to /c/<new-slug>.
   await expect(page).toHaveURL(/\/c\/e2e-net-/, { timeout: 25_000 });
   await expect(page.getByRole("heading", { level: 1, name: new RegExp(`E2E Net ${stamp}`, "i") })).toBeVisible();
+});
+
+// A real Embody export (TDXN v2.1 YAML, GLSL DATs), not a toy fixture: guards
+// the YAML parse + capability scan a dependency bump could break (field 2026-09-11).
+const realTdxn = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "../../../../specimens/generative/plasma-interference.tdxn"),
+  "utf8"
+);
+
+test("signed-in user submits a real Embody-exported .tdxn", async ({ page }) => {
+  await register(page);
+
+  const stamp = Date.now();
+  await page.goto("/contribute");
+  await page.locator('input[name="title"]').fill(`E2E Real ${stamp}`);
+  await fillTdxn(page, realTdxn);
+  await page.locator("[data-submit-go]").click();
+
+  await expect(page).toHaveURL(/\/c\/e2e-real-/, { timeout: 25_000 });
+  await expect(page.getByRole("heading", { level: 1, name: new RegExp(`E2E Real ${stamp}`, "i") })).toBeVisible();
 });
 
 test("signed-in user submits with multiple categories", async ({ page }) => {

--- a/platform/apps/web/e2e/edit-delete.spec.ts
+++ b/platform/apps/web/e2e/edit-delete.spec.ts
@@ -46,6 +46,22 @@ test("owner sees edit/delete controls and can edit metadata", async ({ page }) =
   ).toBeVisible();
 });
 
+test("owner can replace the network from the edit page", async ({ page }) => {
+  const { slug } = await registerAndSubmit(page);
+  await expect(page.locator("[data-owner-actions]")).toBeVisible();
+
+  await page.goto(`/c/${slug}/edit`);
+  await fillTdxn(page, "name: e2e_replaced\ntype: baseCOMP\noperators: []\n");
+  await page.locator("[data-edit-go]").click();
+  await expect(page).toHaveURL(new RegExp(`/c/${slug}$`), { timeout: 15_000 });
+  await expect(page.locator("[data-owner-actions]")).toBeVisible();
+
+  // Edit prefills the STORED network. A drifted payload key once saved the
+  // metadata and silently dropped the network (field 2026-09-11).
+  await page.goto(`/c/${slug}/edit`);
+  await expect(page.locator('textarea[name="tdn"]')).toHaveValue(/e2e_replaced/);
+});
+
 test("owner can delete a specimen", async ({ page, request }) => {
   const { slug } = await registerAndSubmit(page);
 

--- a/platform/apps/web/src/pages/c/[slug]/edit.astro
+++ b/platform/apps/web/src/pages/c/[slug]/edit.astro
@@ -615,7 +615,9 @@ const currentLicenseLabel =
       level: String(data.get("level") || "intermediate"),
       categories: categoriesSel,
       requires: data.getAll("requires").map(String),
-      tdxn: String(data.get("tdn") || ""),
+      // Wire key stays `tdn` (frozen C4); the server ignores any other key, so
+      // a renamed key saved metadata but silently dropped the network (field 2026-09-11).
+      tdn: String(data.get("tdn") || ""),
       ...(thumbnail ? { thumbnail } : {})
     };
 

--- a/platform/apps/web/src/pages/contribute.astro
+++ b/platform/apps/web/src/pages/contribute.astro
@@ -558,7 +558,9 @@ const defaultLicense = licenseOptions[0] ?? { value: "CC-BY-4.0", label: "CC-BY-
       level: String(data.get("level") || "intermediate"),
       categories: categoriesSel,
       requires: data.getAll("requires").map(String),
-      tdxn: tdxnRaw,
+      // Wire key stays `tdn` (frozen C4, SubmitRequest.tdn); the TDXN rename
+      // sent `tdxn` and every submit 400'd "tdn is required." (field 2026-09-11).
+      tdn: tdxnRaw,
       thumbnail,
       visibility: data.get("visibility") === "public" ? "public" : "private",
       turnstileToken


### PR DESCRIPTION
Specimen submission on embody.tools has failed for every user since the 2026-09-07 deploy (v6.2.40), and network edits have been silently dropped.

**Cause:** the TDN -> TDXN site rename (22dec492) changed the client payload key on `/contribute` and `/c/<slug>/edit` from `tdn` to `tdxn`. The specimens API (`api/specimens/index.ts` reads `raw.tdn`; `api/specimens/[slug].ts` reads `raw.tdn`) and the `SubmitRequest` contract still expect `tdn`, which the rename commit itself lists as frozen wire (C4).
- Submit: 400 `tdn is required.` and the page stays on /contribute.
- Edit: the PUT returns 200 and the page says "saved", but the server skips the network branch and keeps the old network.

**Fix:** both pages send `tdn` again (one line each).

**Tests:** two new e2e tests, submitting a real Embody-exported `.tdxn` (`specimens/generative/plasma-interference.tdxn`) and replacing the network from the edit page, then re-reading the stored network. Neither path was covered before.

**Verified locally**, on a fresh D1 against the dev server:
- contribute.spec.ts + edit-delete.spec.ts: 10 passed, including both new tests. The one failure, "anonymous DELETE is rejected", needs the seeded `murmuration` row that the quick run skipped; its 401/403 assertion passed.
- `astro check`: 0 errors. `astro build`: OK. Diff is pure ASCII.

Found by the e2e triage for the upcoming CI deploy gate, which will run these tests on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
