### PR TITLE
Platform CI: gate deploys on the e2e suite and smoke-test prod

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -1,13 +1,18 @@
 name: Platform CI
 
+# specimens/** too: e2e seeds R2 from it and checks it against seed.sql, and an
+# Embody save re-exports it in commits that touch no platform/ file (field
+# 2026-09-11). Drift must fail on the commit that makes it, not a later PR.
 on:
   push:
     paths:
       - 'platform/**'
+      - 'specimens/**'
       - '.github/workflows/platform-ci.yml'
   pull_request:
     paths:
       - 'platform/**'
+      - 'specimens/**'
       - '.github/workflows/platform-ci.yml'
 
 permissions:
@@ -54,6 +59,165 @@ jobs:
         run: npm run test --workspace=@embody/scanner-ts
 
   # ---------------------------------------------------------------------------
+  # Playwright e2e against `astro dev` on local miniflare D1/R2 -- the only job
+  # that runs Better Auth against a real D1. A green typecheck + build shipped a
+  # 500 on every /api/auth/* for ~23h (field 2026-09-11); deploy now needs this
+  # job, so a dependency bump that breaks auth (or any e2e flow) never ships.
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: platform/apps/web
+    env:
+      E2E_PORT: '4321'
+      WRANGLER_SEND_METRICS: 'false'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: platform/package-lock.json
+
+      - name: Install dependencies
+        working-directory: platform
+        run: npm ci
+
+      # Browsers are cached per Playwright version. The apt packages are not,
+      # so a cache hit still installs the system deps.
+      - name: Resolve Playwright version
+        id: playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps --only-shell chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      # .dev.vars is gitignored. ENVIRONMENT=development turns off Turnstile,
+      # both rate limiters and Secure-only cookies (plain http here). The auth
+      # secret is random per run and never printed.
+      - name: Write .dev.vars
+        run: |
+          umask 077
+          printf 'ENVIRONMENT=development\nBETTER_AUTH_SECRET=%s\n' "$(openssl rand -hex 32)" > .dev.vars
+
+      # --local needs no Cloudflare login; under CI wrangler auto-confirms.
+      - name: Apply D1 migrations (local)
+        run: npx wrangler d1 migrations apply embody --local
+
+      # global.setup.ts reseeds D1 only. The collection and viewer specs also
+      # need the specimen .tdxn blobs in local R2, keyed by sha256 (= tdn_r2_key
+      # in seed.sql). Reads specimens/manifest.json: the committed
+      # scripts/.seed-blobs.manifest.json holds absolute Windows paths.
+      - name: Seed local R2 with specimen blobs
+        run: |
+          count=0
+          while read -r rel; do
+            f="../../../specimens/$rel"
+            sha="$(sha256sum "$f" | cut -d' ' -f1)"
+            if ! grep -q "'$sha'" src/server/seed.sql; then
+              echo "::error::specimens/$rel hashes to $sha, which seed.sql does not reference. Rerun scripts/build-specimen-data.py."
+              exit 1
+            fi
+            npx wrangler r2 object put "embody-blobs/$sha" --file="$f" --local < /dev/null
+            count=$((count + 1))
+          done < <(node -e 'for (const s of require("../../../specimens/manifest.json").specimens) console.log(s.tdxn_path)')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::specimens/manifest.json listed no specimens"
+            exit 1
+          fi
+          echo "seeded $count specimen blobs"
+
+      # A cold node_modules/.vite can kill the first `astro dev` boot: the SSR
+      # optimizer finds a late dep, reloads, and workerd imports a chunk that was
+      # just replaced (field 2026-09-11). Boot until the auth + collection pages
+      # serve, retrying, so Playwright's own webServer starts on a warm cache.
+      - name: Warm the Vite dep cache
+        timeout-minutes: 12
+        env:
+          ASTRO_DEV_BACKGROUND: '1'
+        run: |
+          base="http://127.0.0.1:$E2E_PORT"
+          log="$RUNNER_TEMP/astro-warm.log"
+          serves() {
+            code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 60 "$base$1" || true)"
+            [ "$code" -ge 200 ] && [ "$code" -lt 500 ]
+          }
+          for attempt in 1 2 3; do
+            ../../node_modules/.bin/astro dev --port "$E2E_PORT" --host 127.0.0.1 > "$log" 2>&1 &
+            pid=$!
+            ok=0
+            for _ in $(seq 1 60); do
+              kill -0 "$pid" 2>/dev/null || break
+              if serves /; then
+                ok=1
+                for path in /signin /forgot-password /collection /c/murmuration /contribute /api/auth/get-session; do
+                  serves "$path" || ok=0
+                done
+                break
+              fi
+              sleep 2
+            done
+            kill -0 "$pid" 2>/dev/null || ok=0
+            kill "$pid" 2>/dev/null || true
+            for _ in $(seq 1 15); do
+              kill -0 "$pid" 2>/dev/null || break
+              sleep 1
+            done
+            kill -9 "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            for _ in $(seq 1 30); do
+              curl -s -o /dev/null --max-time 2 "$base/" || break
+              sleep 1
+            done
+            if [ "$ok" = 1 ]; then
+              echo "astro dev served every warm-up page on attempt $attempt"
+              exit 0
+            fi
+            echo "::warning::astro dev warm-up attempt $attempt failed; log tail follows"
+            tail -n 40 "$log"
+          done
+          echo "::error::astro dev never served the warm-up pages in 3 attempts"
+          exit 1
+
+      # Serial run (workers: 1, retries: 1 under CI) against a fresh astro dev
+      # started by playwright.config.ts's webServer; global.setup.ts resets D1.
+      - name: Run Playwright
+        env:
+          CI: 'true'
+        run: npx playwright test
+
+      # Report + traces for triage, failures only. .dev.vars never rides along:
+      # it is outside these paths, and hidden files are excluded by default.
+      - name: Upload Playwright results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-results
+          path: |
+            platform/apps/web/playwright-report/
+            platform/apps/web/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
   # Gate the Cloudflare deploy on its secret actually being configured, so a repo
   # that has NOT set CLOUDFLARE_API_TOKEN yet gets a GREEN run (deploy skipped +
   # a warning annotation) instead of a red one. Secrets cannot be read in a
@@ -77,17 +241,17 @@ jobs:
             echo "::warning title=Cloudflare deploy skipped::Set CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID repo secrets to enable auto-deploy of embody-web to embody.tools."
           fi
 
-  # Cloudflare deploy. Runs ONLY on push to main, after build-and-test passes
-  # (a red typecheck/build never ships) AND the deploy secret is set. wrangler
-  # deploy reads platform/apps/web/wrangler.jsonc (name: embody-web), so it always
-  # targets the correct Worker and its embody.tools custom domain.
+  # Cloudflare deploy. Runs ONLY on push to main, after build-and-test AND e2e
+  # pass (a red typecheck/build/e2e never ships) AND the deploy secret is set.
+  # wrangler deploy reads platform/apps/web/wrangler.jsonc (name: embody-web), so
+  # it always targets the correct Worker and its embody.tools custom domain.
   #
   # Requires two repo secrets (Settings -> Secrets and variables -> Actions):
   #   CLOUDFLARE_API_TOKEN   - token with the "Edit Cloudflare Workers" template
   #                            (Workers Scripts:Edit + the embody.tools zone).
   #   CLOUDFLARE_ACCOUNT_ID  - the account that owns the embody-web Worker.
   deploy:
-    needs: [build-and-test, check-deploy-secrets]
+    needs: [build-and-test, e2e, check-deploy-secrets]
     if: needs.check-deploy-secrets.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -118,3 +282,80 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: platform/apps/web
+
+      # Post-deploy smoke: e2e runs on miniflare, prod runs on real D1 (field
+      # 2026-09-11). One read-only GET + one bogus sign-in: never a sign-up, never
+      # an email. Retries ride out edge propagation; the 15 s gap keeps our POSTs
+      # under Better Auth's /sign-in limit (3 per 10 s) and ours (10 per 300 s).
+      - name: Smoke-test production auth
+        timeout-minutes: 10
+        env:
+          SMOKE_BASE: https://embody.tools
+        run: |
+          attempts=6
+          gap=15
+          body="$RUNNER_TEMP/smoke-body"
+          hdrs="$RUNNER_TEMP/smoke-headers"
+          snippet() { head -c 300 "$body" 2>/dev/null | tr -d '\r\n'; }
+          fail() {
+            echo "::error title=Production auth smoke failed::$1"
+            echo "::error title=Roll back embody-web::Run 'npx wrangler rollback' from platform/apps/web, or Cloudflare dashboard > Workers > embody-web > Deployments."
+            exit 1
+          }
+
+          probe() {
+            # $1 expected status, $2 label, rest: curl args. Bounded retries.
+            want="$1"
+            label="$2"
+            shift 2
+            code=000
+            for i in $(seq 1 "$attempts"); do
+              code="$(curl -sS -o "$body" -D "$hdrs" -w '%{http_code}' --max-time 20 \
+                -A 'embody-ci-smoke (+github actions)' "$@" || true)"
+              if [ "$code" = "$want" ]; then
+                echo "ok: $label -> $code (attempt $i)"
+                return 0
+              fi
+              if grep -qi '^cf-mitigated:' "$hdrs" 2>/dev/null; then
+                # Not a deploy fault, so no rollback advice -- but still unverified.
+                echo "::error title=Production auth smoke blocked::$label was challenged by Cloudflare (cf-mitigated, HTTP $code), so auth is UNVERIFIED. Let the smoke through WAF / Bot Fight Mode, then check embody.tools by hand."
+                exit 1
+              fi
+              echo "attempt $i/$attempts: $label -> HTTP $code, want $want. Body: $(snippet)"
+              if [ "$i" -lt "$attempts" ]; then
+                sleep "$gap"
+              fi
+            done
+            fail "$label never returned HTTP $want (last: $code, body: $(snippet)). Auth is likely down on $SMOKE_BASE."
+          }
+
+          check_auth() {
+            # Anonymous get-session is 200 + JSON null. Every auth route runs the
+            # adapter first, so a D1 fault shows up here as a 500.
+            probe 200 "GET /api/auth/get-session" \
+              -H 'Accept: application/json' \
+              "$SMOKE_BASE/api/auth/get-session"
+            if [ "$(tr -d '[:space:]' < "$body")" != "null" ]; then
+              fail "get-session returned 200 but not the anonymous null body: $(snippet)"
+            fi
+            # Unknown address -> 401 INVALID_EMAIL_OR_PASSWORD. Nothing is created
+            # or emailed (Better Auth hashes a dummy password and answers 401).
+            probe 401 "POST /api/auth/sign-in/email (unknown user)" \
+              -X POST \
+              -H 'Content-Type: application/json' \
+              -H "Origin: $SMOKE_BASE" \
+              --data '{"email":"ci-smoke@example.invalid","password":"ci-smoke-not-a-real-password"}' \
+              "$SMOKE_BASE/api/auth/sign-in/email"
+            if ! grep -q 'INVALID_EMAIL_OR_PASSWORD' "$body"; then
+              fail "sign-in returned 401 without INVALID_EMAIL_OR_PASSWORD: $(snippet)"
+            fi
+          }
+
+          # Until the new version reaches every edge the OLD one answers, so a probe
+          # right after deploy can pass a broken release. Settle, then pass twice
+          # (field 2026-09-11).
+          sleep 45
+          check_auth
+          sleep 30
+          check_auth
+          echo "ok: production auth passed twice, 30 s apart"

--- a/platform/apps/web/README.md
+++ b/platform/apps/web/README.md
@@ -48,10 +48,60 @@ bash scripts/upload-seed-blobs.sh --remote
 wrangler d1 execute embody --remote --file ./src/server/seed.sql
 ```
 
+**Caution (2026-09-11):** `seed.sql` is written for a dev database. On a live D1 it
+drops and rebuilds `specimens_fts` with only the six first-party rows, so every
+community specimen drops out of search, and it deletes the `STALE_SLUGS` rows
+(`ev`, `clean2`, `ff`, `clean-net`, `evil`). Until a targeted re-seed exists,
+review it against production data before running the last command.
+
 In non-production environments, the submit endpoint accepts `turnstileToken: "dev-bypass"`. In
 production the Turnstile gate fails closed: the `dev-bypass` token is never honored, an unknown
 `ENVIRONMENT` is treated as production, and submissions are rejected unless a real Turnstile token
 verifies. See `src/server/turnstile.ts`.
+
+## E2E tests
+
+Playwright specs in `e2e/` run against `astro dev` on local miniflare D1/R2. Each
+run's `e2e/global.setup.ts` resets and reseeds local D1 and registers the e2e
+admin; the specimen blobs must already be in local R2 (see "Local API data").
+From `platform/apps/web/`, with a `.dev.vars` holding `ENVIRONMENT=development`
+and any `BETTER_AUTH_SECRET`:
+
+```sh
+npx playwright install chromium                     # once per Playwright version
+npx wrangler d1 migrations apply embody --local
+npx playwright test                                 # starts astro dev on 127.0.0.1:4321
+E2E_PORT=4461 npx playwright test e2e/auth.spec.ts  # another port, one spec
+```
+
+- `E2E_PORT` picks the port (default 4321); the server binds `127.0.0.1`. Outside
+  CI, a server already listening on that port is reused.
+- AI agents: Astro 7.3 backgrounds `astro dev` when it detects one, so the config
+  sets `ASTRO_DEV_BACKGROUND=1` on the server Playwright starts. An agent can
+  also start its own (`../../node_modules/.bin/astro dev --port P --host 127.0.0.1`
+  daemonizes), run with `E2E_PORT=P`, and stop it with `astro dev stop`.
+- A boot on a cold `node_modules/.vite` can die in Vite's dep optimizer ("The
+  file does not exist at .../deps_ssr/..."); so can the first boot after
+  switching between an agent-started and a Playwright-started server, since
+  their Vite config hashes differ. Start it again.
+
+**CI.** The `e2e` job in `.github/workflows/platform-ci.yml` runs the whole suite
+on every push and PR that touches `platform/**` or `specimens/**`, and `deploy`
+needs it, so a red e2e run never ships. Failures upload the HTML report and
+traces as the `playwright-results` artifact.
+
+**Specimen re-exports.** Every Embody re-export changes a specimen's bytes (the
+header carries `exported_at`), so its sha256 no longer matches `seed.sql` and
+the `Seed local R2` step fails. Regenerate and commit the seed data in the same
+commit: `python3 scripts/build-specimen-data.py`.
+
+**Production smoke.** Right after `wrangler deploy`, the deploy job checks
+`https://embody.tools`: `GET /api/auth/get-session` must return 200 with `null`,
+and a sign-in for an unknown address must return 401 `INVALID_EMAIL_OR_PASSWORD`.
+It waits for the new version to reach the edge, must pass twice 30 s apart, and
+never signs up or sends mail. If it fails, roll back
+with `npx wrangler rollback` (deploy token) or Cloudflare dashboard > Workers >
+embody-web > Deployments.
 
 ## Production environment / secrets
 

--- a/platform/apps/web/e2e/auth.spec.ts
+++ b/platform/apps/web/e2e/auth.spec.ts
@@ -1,9 +1,14 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 
 // Account lifecycle. In dev (no RESEND_API_KEY) email verification is skipped,
 // so register signs the user straight in. Each run uses a unique email.
 const pw = "e2e-passw0rd";
 const newEmail = () => `e2e-${Date.now()}-${Math.floor(performance.now())}@example.test`;
+
+async function fillSignIn(page: Page, email = "nobody@example.test", password = "definitely-wrong") {
+  await page.locator('input[name="email"]').fill(email);
+  await page.locator('input[name="password"]').fill(password);
+}
 
 test("register creates an account and signs in", async ({ page }) => {
   const email = newEmail();
@@ -53,11 +58,178 @@ test("sign out, then sign back in", async ({ page }) => {
   await expect(page.getByRole("button", { name: /account menu/i })).toBeVisible();
 });
 
-test("wrong password is rejected", async ({ page }) => {
+// Pins the STATUS, not just a visible error: during the 2026-09-11 outage every
+// /api/auth/* was an empty 500 and this box still read "invalid email or password.".
+test("wrong password is rejected with a 401 and the credential message", async ({ page }) => {
   await page.goto("/signin");
-  await page.locator('input[name="email"]').fill("nobody@example.test");
-  await page.locator('input[name="password"]').fill("definitely-wrong");
-  await page.locator("[data-auth-submit]").click();
-  await expect(page.locator("[data-auth-error]")).toBeVisible({ timeout: 15_000 });
+  await fillSignIn(page);
+  const [res] = await Promise.all([
+    page.waitForResponse(
+      (r) => new URL(r.url()).pathname === "/api/auth/sign-in/email" && r.request().method() === "POST",
+      { timeout: 15_000 }
+    ),
+    page.locator("[data-auth-submit]").click()
+  ]);
+  expect(res.status()).toBe(401);
+  await expect(page.locator("[data-auth-error]")).toHaveText(/invalid email or password/i, { timeout: 15_000 });
   await expect(page).toHaveURL(/\/signin/);
+});
+
+// --- server failure copy (field 2026-09-11) ---------------------------------
+// A 5xx, a non-JSON body, or a dropped connection must read as "unavailable",
+// never as a credential or link problem, and must hand the button back.
+// page.route stubs the endpoint, so these pin the client copy; the happy path
+// and the canary below pin the real server.
+
+const outages: Array<{ name: string; stub: (route: Route) => Promise<void> }> = [
+  { name: "500 with an empty body", stub: (r) => r.fulfill({ status: 500, body: "" }) },
+  { name: "502 with an html body", stub: (r) => r.fulfill({ status: 502, contentType: "text/html", body: "<h1>bad gateway</h1>" }) },
+  { name: "network failure", stub: (r) => r.abort("failed") }
+];
+
+for (const { name, stub } of outages) {
+  test(`sign-in ${name} reads as unavailable, not a bad password`, async ({ page }) => {
+    await page.route("**/api/auth/sign-in/email", stub);
+    await page.goto("/signin");
+    await fillSignIn(page);
+    const submit = page.locator("[data-auth-submit]");
+    await submit.click();
+    const err = page.locator("[data-auth-error]");
+    await expect(err).toHaveText(/sign-in is unavailable right now/, { timeout: 15_000 });
+    await expect(err).not.toContainText(/invalid email or password/i);
+    await expect(submit).toBeEnabled();
+    await expect(submit).toHaveText("sign in");
+    await expect(page).toHaveURL(/\/signin/);
+  });
+}
+
+test("sign-in rate limit reads as slow down, not a bad password", async ({ page }) => {
+  // The catch-all limiter answers { error, detail } with no `message`.
+  await page.route("**/api/auth/sign-in/email", (r) =>
+    r.fulfill({
+      status: 429,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "rate_limited", detail: "Too many attempts. Please slow down and try again shortly." })
+    })
+  );
+  await page.goto("/signin");
+  await fillSignIn(page);
+  await page.locator("[data-auth-submit]").click();
+  const err = page.locator("[data-auth-error]");
+  await expect(err).toHaveText(/too many attempts/, { timeout: 15_000 });
+  await expect(err).not.toContainText(/invalid email or password/i);
+});
+
+// Only Better Auth code EMAIL_NOT_VERIFIED means "verify your email"; any other
+// 403 is a server fault and must not send the user to their inbox (field 2026-09-11).
+for (const { code, verify } of [
+  { code: "EMAIL_NOT_VERIFIED", verify: true },
+  { code: "INVALID_ORIGIN", verify: false }
+]) {
+  test(`sign-in 403 ${code} ${verify ? "asks to verify" : "is not read as unverified"}`, async ({ page }) => {
+    await page.route("**/api/auth/sign-in/email", (r) =>
+      r.fulfill({ status: 403, contentType: "application/json", body: JSON.stringify({ code, message: code.toLowerCase() }) })
+    );
+    await page.goto("/signin");
+    await fillSignIn(page);
+    await page.locator("[data-auth-submit]").click();
+    const err = page.locator("[data-auth-error]");
+    await expect(err).toBeVisible({ timeout: 15_000 });
+    if (verify) {
+      await expect(err).toContainText("verified yet");
+      await expect(page.locator("[data-resend]")).toBeVisible();
+    } else {
+      await expect(err).not.toContainText("verified");
+      await expect(page.locator("[data-resend]")).toBeHidden();
+    }
+  });
+}
+
+test("register outage reads as unavailable", async ({ page }) => {
+  await page.route("**/api/auth/sign-up/email", (r) => r.fulfill({ status: 500, body: "" }));
+  await page.goto("/signin");
+  await page.locator('[data-mode="register"]').click();
+  await page.locator('input[name="name"]').fill("E2E Tester");
+  await fillSignIn(page, newEmail(), pw);
+  const submit = page.locator("[data-auth-submit]");
+  await submit.click();
+  const err = page.locator("[data-auth-error]");
+  await expect(err).toHaveText(/registration is unavailable right now/, { timeout: 15_000 });
+  await expect(err).not.toContainText("could not create the account");
+  await expect(submit).toBeEnabled();
+  await expect(submit).toHaveText("create account");
+});
+
+test("forgot-password outage reads as unavailable, not a failed send", async ({ page }) => {
+  await page.route("**/api/auth/request-password-reset", (r) => r.fulfill({ status: 500, body: "" }));
+  await page.goto("/forgot-password");
+  await page.locator('input[name="email"]').fill("nobody@example.test");
+  const submit = page.locator("[data-forgot-submit]");
+  await submit.click();
+  const err = page.locator("[data-auth-error]");
+  await expect(err).toHaveText(/password reset is unavailable right now/, { timeout: 15_000 });
+  await expect(err).not.toContainText("could not send the reset link");
+  await expect(page.locator("[data-auth-notice]")).toHaveText("");
+  await expect(submit).toBeEnabled();
+  await expect(submit).toHaveText("send reset link");
+});
+
+test("reset-password outage reads as unavailable, not an expired link", async ({ page }) => {
+  await page.route("**/api/auth/reset-password", (r) => r.fulfill({ status: 500, body: "" }));
+  await page.goto("/reset-password?token=e2e-bogus-token");
+  await page.locator('input[name="password"]').fill(pw);
+  await page.locator('input[name="confirm"]').fill(pw);
+  const submit = page.locator("[data-reset-submit]");
+  await submit.click();
+  const err = page.locator("[data-auth-error]");
+  await expect(err).toHaveText(/password reset is unavailable right now/, { timeout: 15_000 });
+  await expect(err).not.toContainText("expired");
+  await expect(submit).toBeEnabled();
+  await expect(submit).toHaveText("set new password");
+});
+
+// --- real server ------------------------------------------------------------
+
+test("forgot-password for a real account returns 200 and the neutral confirmation", async ({ page, request, baseURL }) => {
+  // Own cookie jar (the `request` fixture), so the page stays signed out --
+  // /forgot-password redirects a signed-in user. A real account walks the
+  // verification-row write; with no RESEND_API_KEY sendEmail no-ops.
+  const email = newEmail();
+  const signUp = await request.post("/api/auth/sign-up/email", {
+    data: { email, password: pw, name: "E2E Reset" },
+    headers: { Origin: baseURL! },
+    timeout: 15_000
+  });
+  expect(signUp.status(), await signUp.text()).toBe(200);
+
+  await page.goto("/forgot-password");
+  await page.locator('input[name="email"]').fill(email);
+  const [res] = await Promise.all([
+    page.waitForResponse(
+      (r) => new URL(r.url()).pathname === "/api/auth/request-password-reset" && r.request().method() === "POST",
+      { timeout: 15_000 }
+    ),
+    page.locator("[data-forgot-submit]").click()
+  ]);
+  expect(res.status()).toBe(200);
+  await expect(page.locator("[data-auth-notice]")).toContainText("a reset link is on its way", { timeout: 15_000 });
+  await expect(page.locator("[data-auth-error]")).toHaveText("");
+});
+
+test("auth API canary: get-session 200, bogus sign-in 401", async ({ request, baseURL }) => {
+  // Better Auth 1.7's schema check 500'd every /api/auth/* on D1 with an empty
+  // body (field 2026-09-11); the deploy job's prod smoke runs the same two
+  // probes. Origin mirrors global.setup.ts: Better Auth checks it on POSTs that
+  // carry one (or a cookie) against the request's own origin.
+  const session = await request.get("/api/auth/get-session", { timeout: 15_000 });
+  expect(session.status(), await session.text()).toBe(200);
+  expect(await session.json()).toBeNull();
+
+  const signIn = await request.post("/api/auth/sign-in/email", {
+    data: { email: "nobody@example.test", password: "definitely-wrong" },
+    headers: { Origin: baseURL! },
+    timeout: 15_000
+  });
+  expect(signIn.status(), await signIn.text()).toBe(401);
+  expect((await signIn.json()).code).toBe("INVALID_EMAIL_OR_PASSWORD");
 });

--- a/platform/apps/web/e2e/collection.spec.ts
+++ b/platform/apps/web/e2e/collection.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "@playwright/test";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 // Read path: the Collection is the public core of the site. These assert the
 // seeded first-party specimens render and their TDXN blobs are served.
@@ -10,6 +14,25 @@ const SPECIMENS = [
   "plasma-interference",
   "mandelbulb-march",
 ];
+
+// First-party author handle: AUTHOR_HANDLE in scripts/build-specimen-data.py
+// ('envoy' since 9fb23435; the test still said embody.tools, field 2026-09-11).
+const FIRST_PARTY_HANDLE = "envoy";
+
+// Expected blob for a seeded slug, read from the generated seed.sql version row
+// (tdn_r2_key, tdn_sha256, size_bytes) so a specimen regen cannot strand a
+// hard-coded size here again (20494 went stale on 2026-08-30).
+function seededBlob(slug: string): { sha256: string; size: number } {
+  const seed = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), "../src/server/seed.sql"),
+    "utf8"
+  );
+  const row = new RegExp(
+    `[(]'ver-${slug}', 'sp-${slug}', [0-9]+, '([0-9a-f]{64})', '([0-9a-f]{64})', ([0-9]+),`
+  ).exec(seed);
+  if (!row) throw new Error(`seed.sql has no version row for ${slug}`);
+  return { sha256: row[2], size: Number(row[3]) };
+}
 
 test("homepage renders hero + real featured cards", async ({ page }) => {
   await page.goto("/");
@@ -33,17 +56,17 @@ test("collection lists the seeded specimens", async ({ page }) => {
 });
 
 test("collection ?author= filters the grid to one author (SSR)", async ({ page }) => {
-  // The first-party seed specimens are all authored by embody.tools. The SSR
-  // author facet (?author=<handle>) must apply on first paint -- the seeded
+  // The first-party seed specimens are all authored by FIRST_PARTY_HANDLE. The
+  // SSR author facet (?author=<handle>) must apply on first paint -- the seeded
   // specimens stay visible and every card on the page is by that author.
-  await page.goto("/collection?author=embody.tools");
+  await page.goto(`/collection?author=${FIRST_PARTY_HANDLE}`);
   for (const slug of SPECIMENS) {
     await expect(page.locator(`[data-specimen][data-slug="${slug}"]`)).toBeVisible();
   }
   const handles = await page
     .locator("[data-card-grid] a.specimen-card__author .specimen-card__author-handle")
     .evaluateAll((els) => [...new Set(els.map((e) => (e.textContent || "").trim()))]);
-  expect(handles).toEqual(["@embody.tools"]);
+  expect(handles).toEqual([`@${FIRST_PARTY_HANDLE}`]);
 });
 
 test("cover network graph fits the cover (no min-height clipping)", async ({ page }) => {
@@ -75,9 +98,12 @@ test("specimen page renders + TDXN blob downloads", async ({ page, request }) =>
   await expect(page.getByRole("heading", { level: 1, name: /murmuration/i })).toBeVisible();
 
   const res = await request.get("/api/specimens/murmuration/tdn");
-  expect(res.status()).toBe(200);
+  expect(res.status(), "local R2 needs the seed blobs (scripts/upload-seed-blobs.sh)").toBe(200);
   const body = await res.body();
-  expect(body.byteLength).toBe(20494); // content-addressed: matches seed.sql size
+  // Content-addressed: the bytes served are exactly the blob the version row names.
+  const expected = seededBlob("murmuration");
+  expect(body.byteLength).toBe(expected.size);
+  expect(createHash("sha256").update(body).digest("hex")).toBe(expected.sha256);
 });
 
 test("card copy puts the _embody_tdn envelope on the clipboard", async ({ page, context }) => {

--- a/platform/apps/web/e2e/paste-envelope.spec.ts
+++ b/platform/apps/web/e2e/paste-envelope.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+// A user's real flow: Ctrl+Shift+C in Embody puts a JSON _embody_tdn envelope
+// (contract C1) on the clipboard; they paste it on /contribute and submit.
+const here = dirname(fileURLToPath(import.meta.url));
+const network = parseYaml(readFileSync(resolve(here, "../../../../specimens/generative/plasma-interference.tdxn"), "utf8"));
+const envelope = JSON.stringify(
+  { _embody_tdn: 1, source: "embody", copy_id: "e2e0000000000001", sha256: "0".repeat(64), tdn: network },
+  null,
+  2
+);
+const pw = "e2e-passw0rd";
+
+for (const via of ["ctrl+v", "toolbar"] as const) {
+  test(`pasted Embody clipboard envelope submits (${via})`, async ({ page, context, baseURL }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], { origin: baseURL });
+    await page.goto("/signin");
+    await page.locator('[data-mode="register"]').click();
+    await page.locator('input[name="name"]').fill("E2E Paster");
+    await page.locator('input[name="email"]').fill(`e2e-paste-${Date.now()}@example.test`);
+    await page.locator('input[name="password"]').fill(pw);
+    await page.locator("[data-auth-submit]").click();
+    await expect(page).not.toHaveURL(/\/signin/, { timeout: 15_000 });
+
+    const stamp = Date.now();
+    await page.goto("/contribute");
+    await page.locator('input[name="title"]').fill(`E2E Paste ${stamp}`);
+    await page.evaluate((t) => navigator.clipboard.writeText(t), envelope);
+    if (via === "ctrl+v") {
+      await page.locator(".tdxn-editor__cm .cm-content").click();
+      await page.keyboard.press("ControlOrMeta+v");
+    } else {
+      await page.getByRole("button", { name: "Paste TDXN from clipboard" }).click();
+    }
+    // Unwrapped to the bare YAML body, and the submit gate reads it as valid.
+    await expect(page.locator(".tdxn-editor__cm .cm-content")).toContainText("format: tdxn");
+    await expect(page.locator(".tdxn-editor__cm .cm-content")).not.toContainText("_embody_tdn");
+    await expect(page.locator(".tdxn-editor")).toHaveAttribute("data-valid", "true");
+
+    const [resp] = await Promise.all([
+      page.waitForResponse((r) => r.url().endsWith("/api/specimens") && r.request().method() === "POST"),
+      page.locator("[data-submit-go]").click(),
+    ]);
+    expect(resp.status()).toBe(201);
+    await expect(page).toHaveURL(/\/c\/e2e-paste-/, { timeout: 25_000 });
+    await expect(page.getByRole("heading", { level: 1, name: new RegExp(`E2E Paste ${stamp}`, "i") })).toBeVisible();
+  });
+}

--- a/platform/apps/web/e2e/viewer-drilldown.spec.ts
+++ b/platform/apps/web/e2e/viewer-drilldown.spec.ts
@@ -30,7 +30,10 @@ test("specimen viewer drills into a COMP and climbs back out", async ({ page }) 
   expect(compName, "an enterable COMP must have a name").toBeTruthy();
   const rootOps = await opNames();
 
-  // Double-click the COMP -> descend into its sub-network.
+  // Double-click the UNSELECTED COMP -> descend into its sub-network. Never
+  // select it first: the dblclick's 1st click must change the selection, which
+  // once rebuilt every node and hid the tiles for a frame, so the 2nd click
+  // missed the COMP (field 2026-09-11). A pre-click masks that regression.
   await enterable.dblclick();
 
   // Breadcrumb gains a second crumb naming the COMP we entered, and the visible
@@ -45,4 +48,9 @@ test("specimen viewer drills into a COMP and climbs back out", async ({ page }) 
   await crumbs.first().click();
   await expect(crumbs).toHaveCount(1);
   await expect.poll(opNames).toEqual(rootOps);
+
+  // One click selects the COMP: the ring reads SelectedOpContext, not node data.
+  await expect(enterable).not.toHaveClass(/tdxn-operator--selected/);
+  await enterable.click();
+  await expect(enterable).toHaveClass(/tdxn-operator--selected/);
 });

--- a/platform/apps/web/playwright.config.ts
+++ b/platform/apps/web/playwright.config.ts
@@ -3,13 +3,19 @@ import { defineConfig, devices } from "@playwright/test";
 // E2E runs against the local dev server (astro dev -> miniflare D1/R2). In dev,
 // ENVIRONMENT=development so the Turnstile gate accepts the "dev-bypass" token
 // and email verification is skipped -- so signup/submit work without external
-// services. Seed the local DB first: see e2e/README or run
+// services. Seed the local DB first: see "E2E tests" in README.md, or run
 //   python3 scripts/build-specimen-data.py
 //   wrangler d1 migrations apply embody --local
 //   wrangler d1 execute embody --local --file ./src/server/seed.sql
 //   bash scripts/upload-seed-blobs.sh
-const PORT = 4321;
-const BASE_URL = `http://localhost:${PORT}`;
+//
+// E2E_PORT picks the port (default 4321). 127.0.0.1, never localhost: the dev
+// server binds IPv4 only, and localhost can resolve to ::1 first.
+const PORT = Number(process.env.E2E_PORT || 4321);
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535) {
+  throw new Error(`E2E_PORT must be a TCP port number, got "${process.env.E2E_PORT}"`);
+}
+const BASE_URL = `http://127.0.0.1:${PORT}`;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -17,7 +23,9 @@ export default defineConfig({
   workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? "line" : [["list"]],
+  // CI also writes playwright-report/ (with the retry traces) for the
+  // failure artifact the platform-ci e2e job uploads.
+  reporter: process.env.CI ? [["line"], ["html", { open: "never" }]] : [["list"]],
   timeout: 30_000,
   expect: { timeout: 10_000 },
   use: {
@@ -36,9 +44,15 @@ export default defineConfig({
     }
   ],
   webServer: {
-    command: "npm run dev",
+    command: `npm run dev -- --port ${PORT} --host 127.0.0.1`,
     url: BASE_URL,
+    // Locally a server already listening on PORT is reused; CI starts fresh.
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    // Astro 7.3 backgrounds `astro dev` and exits when it detects an AI agent
+    // (am-i-vibing), so Playwright would see its server die at once. This keeps
+    // it in the foreground. An agent may instead start `astro dev --port P
+    // --host 127.0.0.1` itself and run with E2E_PORT=P to reuse it.
+    env: { ASTRO_DEV_BACKGROUND: "1" },
   },
 });

--- a/platform/apps/web/scripts/build-specimen-data.py
+++ b/platform/apps/web/scripts/build-specimen-data.py
@@ -191,7 +191,8 @@ def main() -> int:
                 "name": spec["name"],
                 "description": spec["description"],
                 "category": spec["category"],
-                "difficulty": spec["difficulty"],
+                # manifest.json keeps `difficulty`; D1 + fixtures say `level` (0008).
+                "level": spec["difficulty"],
                 # requires is a JSON array in D1 (post-0009_requires_multi). Keep
                 # it a clean list here; the legacy scalar 'none'/'' -> []. The SQL
                 # emitter json.dumps it so json_each(requires) never sees invalid
@@ -274,6 +275,10 @@ def write_seed_sql(rows: list[dict]) -> None:
         "DELETE FROM specimen_versions WHERE specimen_id IN "
         f"(SELECT id FROM specimens WHERE slug IN ({slug_list}));"
     )
+    a(
+        "DELETE FROM specimen_categories WHERE specimen_id IN "
+        f"(SELECT id FROM specimens WHERE slug IN ({slug_list}));"
+    )
     a(f"DELETE FROM specimens WHERE slug IN ({slug_list});")
     a("")
     # Also purge any row whose deterministic id we are about to (re)insert, so a
@@ -286,6 +291,7 @@ def write_seed_sql(rows: list[dict]) -> None:
     )
     a(f"DELETE FROM specimen_tags WHERE specimen_id IN ({real_sp_ids});")
     a(f"DELETE FROM specimen_versions WHERE specimen_id IN ({real_sp_ids});")
+    a(f"DELETE FROM specimen_categories WHERE specimen_id IN ({real_sp_ids});")
     a(f"DELETE FROM specimens WHERE id IN ({real_sp_ids});")
     a("")
 
@@ -307,7 +313,7 @@ def write_seed_sql(rows: list[dict]) -> None:
     a("-- Specimens (real first-party metadata from specimens/manifest.json).")
     a(
         "INSERT OR REPLACE INTO specimens (\n"
-        "  id, slug, author_id, title, description, category, difficulty, requires, op_count,\n"
+        "  id, slug, author_id, title, description, category, level, requires, op_count,\n"
         "  family_summary, current_version_id, thumbnail_key, license, visibility, tier, scan_status,\n"
         "  capability_json, likes_count, views_count, copies_count\n"
         ") VALUES"
@@ -322,7 +328,7 @@ def write_seed_sql(rows: list[dict]) -> None:
             f"    {sql_str(r['name'])},\n"
             f"    {sql_str(r['description'])},\n"
             f"    {sql_str(r['category'])},\n"
-            f"    {sql_str(r['difficulty'])},\n"
+            f"    {sql_str(r['level'])},\n"
             f"    {sql_str(json.dumps(r['requires']))},\n"
             f"    {r['op_count']},\n"
             f"    {sql_str(r['family_summary'])},\n"
@@ -401,6 +407,15 @@ def write_seed_sql(rows: list[dict]) -> None:
         )
         a(f"FROM specimens WHERE id = {sql_str('sp-' + r['slug'])};")
         a("")
+
+    # The level rename (0008) and this join table (0010) were hand edits to
+    # seed.sql, lost when the 2026-08-30 regen rewrote it from this script;
+    # the setup then died on "no column named difficulty" (field 2026-09-11).
+    a("-- Category membership (multi). Seed the join table from each specimen's primary")
+    a("-- category so the collection facet filter (which reads specimen_categories) and")
+    a("-- the category facets list include the seeded rows. Mirrors migration 0010.")
+    a("INSERT OR IGNORE INTO specimen_categories (specimen_id, category)")
+    a("SELECT id, category FROM specimens WHERE category IS NOT NULL AND category <> '';")
 
     SEED_SQL_PATH.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
@@ -505,7 +520,7 @@ def write_fixtures(rows: list[dict]) -> None:
             "slug": r["slug"],
             "name": r["name"],
             "category": r["category"],
-            "difficulty": r["difficulty"],
+            "level": r["level"],
             "description": r["description"],
             "tags": r["tags"],
             "requires": r["requires"],

--- a/platform/apps/web/src/fixtures/specimens.json
+++ b/platform/apps/web/src/fixtures/specimens.json
@@ -3,7 +3,7 @@
     "slug": "murmuration",
     "name": "Murmuration",
     "category": "simulation",
-    "difficulty": "advanced",
+    "level": "advanced",
     "description": "A dense GPU particle swarm that flocks like a starling murmuration at dusk - cohering, separating, aligning, and flowing around a slow invisible attractor with curl-noise wander. True per-neighbor Reynolds flocking computed on the GPU (a Neighbor POP index list iterated in a GLSL POP), rendered as luminous additive point sprites.",
     "tags": [
       "simulation",
@@ -26,7 +26,7 @@
     "slug": "reaction-diffusion",
     "name": "Reaction-Diffusion (Gray-Scott)",
     "category": "generative",
-    "difficulty": "intermediate",
+    "level": "intermediate",
     "description": "A living Gray-Scott reaction-diffusion field. Two chemicals diffuse and react in a GPU feedback loop, growing organic maze and coral patterns that evolve continuously. Usable as a texture, displacement, or mask source.",
     "tags": [
       "feedback",
@@ -46,7 +46,7 @@
     "slug": "kaleidoscope",
     "name": "Kaleidoscope",
     "category": "compositing",
-    "difficulty": "intermediate",
+    "level": "intermediate",
     "description": "A reusable kaleidoscope compositor. Folds any TOP (or its built-in animated source) into an N-fold mirrored mandala that rotates, twists, breathes, and tumbles. Drop it onto any visual via the External source mode.",
     "tags": [
       "compositing",
@@ -67,7 +67,7 @@
     "slug": "noise-terrain",
     "name": "Ridged Mountain Terrain",
     "category": "3d",
-    "difficulty": "advanced",
+    "level": "advanced",
     "description": "A procedural snow-mountain scene. A GLSL POP compute shader displaces a grid into ridged-multifractal peaks that morph in place, shaded by a snow/rock GLSL MAT with elevation-based snow, sun/sky lighting, and atmospheric haze, composited under a procedural sky.",
     "tags": [
       "3d",
@@ -89,7 +89,7 @@
     "slug": "plasma-interference",
     "name": "Plasma (Sine Interference)",
     "category": "generative",
-    "difficulty": "intermediate",
+    "level": "intermediate",
     "description": "A flowing GPU plasma. Two sine-wave fields at slightly detuned scales beat against each other into shimmering moire fringes, a slow rotating domain warp bends the coordinates into liquid motion, and the result is mapped through a cyclic cosine palette. Self-contained and stateless - one GLSL TOP, no input, no feedback - so it drops in anywhere as a VJ loop, texture, or displacement source.",
     "tags": [
       "generative",
@@ -109,7 +109,7 @@
     "slug": "mandelbulb-march",
     "name": "Mandelbulb March",
     "category": "raymarching-sdf",
-    "difficulty": "advanced",
+    "level": "advanced",
     "description": "A raymarched 3D Mandelbulb fractal rendered entirely in one GLSL TOP. The classic distance estimator is marched per pixel against a slowly orbiting camera; orbit-trap values captured during iteration tint the surface, and soft shadows, a fresnel rim, and a proximity glow give it depth. No input, no feedback - a drop-in hero render, a looping VJ source, or a reference for distance-estimated raymarching.",
     "tags": [
       "raymarching",

--- a/platform/apps/web/src/lib/authClient.ts
+++ b/platform/apps/web/src/lib/authClient.ts
@@ -3,3 +3,23 @@ import { createAuthClient } from "better-auth/client";
 // Browser-side Better Auth client. Same-origin: the catch-all route is mounted
 // at /api/auth, which is Better Auth's default basePath, so no baseURL needed.
 export const authClient = createAuthClient();
+
+// A failed call resolves { status, statusText, message?, code? }; a 5xx with an
+// empty body has no message, so pages fell through to their 4xx copy ("invalid
+// email or password.") while auth was down (field 2026-09-11). Only a 4xx may
+// use the server message / fallback; 5xx or a thrown fetch -> unavailable.
+export function authUnavailable(what: string): string {
+  return `${what} is unavailable right now. please try again in a few minutes.`;
+}
+
+export function authErrorMessage(
+  error: { status?: number; message?: string } | null | undefined,
+  what: string,
+  fallback: string
+): string {
+  const status = error?.status ?? 0;
+  // The catch-all limiter's 429 body is { error, detail } -- no message.
+  if (status === 429) return error?.message || "too many attempts. please wait a few minutes and try again.";
+  if (status >= 400 && status < 500) return error?.message || fallback;
+  return authUnavailable(what);
+}

--- a/platform/apps/web/src/pages/api/specimens/index.ts
+++ b/platform/apps/web/src/pages/api/specimens/index.ts
@@ -22,12 +22,12 @@ import { requireUser } from "../../../server/auth";
 import { notifyOwnerNewSpecimen } from "../../../server/notifications";
 import { errorResponse, jsonResponse, serverErrorResponse } from "../../../server/http";
 import { byteLength, putTdxn, putThumbnail } from "../../../server/r2";
-import { checkRateLimit } from "../../../server/rateLimit";
+import { checkRateLimit, rateLimitDisabled } from "../../../server/rateLimit";
 import { verifyTurnstile } from "../../../server/turnstile";
 import { MAX_TDXN_TEXT_CHARS } from "../../../server/tdxn";
 
 // Submit abuse cap: 10 submissions per 10 minutes per client IP. Enforced via
-// KV; with no KV (dev) the limiter allows everything (see rateLimit.ts).
+// KV in production; off in development (rateLimitDisabled, see rateLimit.ts).
 const SUBMIT_RATE_LIMIT = { limit: 10, windowSec: 600 } as const;
 
 export const prerender = false;
@@ -71,16 +71,19 @@ export const POST: APIRoute = async ({ request }) => {
   try {
     // Per-IP fixed-window cap before any expensive work (parse/scan/R2/D1). The
     // CF-Connecting-IP header is set by Cloudflare's edge; "unknown" buckets
-    // callers we can't identify together. No KV (dev) -> always allowed.
-    const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
-    const rate = await checkRateLimit(env.KV, `submit:${clientIp}`, SUBMIT_RATE_LIMIT);
-    if (!rate.ok) {
-      return errorResponse(
-        429,
-        "rate_limited",
-        "Too many submissions. Please slow down and try again shortly.",
-        rate.retryAfter ? { "Retry-After": String(rate.retryAfter) } : undefined
-      );
+    // callers we can't identify together. Skipped in development like every
+    // sibling limiter: miniflare has a KV, so e2e hit 429 at submit 11 (field 2026-09-11).
+    if (!rateLimitDisabled(env)) {
+      const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
+      const rate = await checkRateLimit(env.KV, `submit:${clientIp}`, SUBMIT_RATE_LIMIT);
+      if (!rate.ok) {
+        return errorResponse(
+          429,
+          "rate_limited",
+          "Too many submissions. Please slow down and try again shortly.",
+          rate.retryAfter ? { "Retry-After": String(rate.retryAfter) } : undefined
+        );
+      }
     }
 
     const body = await readSubmitRequest(request);

--- a/platform/apps/web/src/pages/forgot-password.astro
+++ b/platform/apps/web/src/pages/forgot-password.astro
@@ -44,7 +44,7 @@ if (user) {
 </Base>
 
 <script>
-  import { authClient } from "../lib/authClient";
+  import { authClient, authErrorMessage, authUnavailable } from "../lib/authClient";
 
   const form = document.querySelector("[data-forgot-form]") as HTMLFormElement | null;
   const errorBox = document.querySelector("[data-auth-error]") as HTMLParagraphElement | null;
@@ -92,7 +92,7 @@ if (user) {
         redirectTo: `${window.location.origin}/reset-password`
       });
       if (res.error) {
-        showError(res.error.message || "could not send the reset link.");
+        showError(authErrorMessage(res.error, "password reset", "could not send the reset link."));
         return;
       }
       form.hidden = true;
@@ -101,7 +101,7 @@ if (user) {
       );
     } catch (err) {
       console.error("password reset request failed", err);
-      showError("something went wrong. please try again.");
+      showError(authUnavailable("password reset"));
     } finally {
       submitBtn.disabled = false;
       submitBtn.textContent = original;

--- a/platform/apps/web/src/pages/reset-password.astro
+++ b/platform/apps/web/src/pages/reset-password.astro
@@ -55,7 +55,7 @@ const hasToken = token.length > 0 && !tokenError;
 </Base>
 
 <script>
-  import { authClient } from "../lib/authClient";
+  import { authClient, authErrorMessage, authUnavailable } from "../lib/authClient";
 
   const card = document.querySelector(".auth-card") as HTMLDivElement | null;
   const form = document.querySelector("[data-reset-form]") as HTMLFormElement | null;
@@ -109,7 +109,9 @@ const hasToken = token.length > 0 && !tokenError;
     try {
       const res = await authClient.resetPassword({ newPassword: password, token });
       if (res.error) {
-        showError(res.error.message || "could not reset the password. the link may have expired.");
+        showError(
+          authErrorMessage(res.error, "password reset", "could not reset the password. the link may have expired.")
+        );
         return;
       }
       form.hidden = true;
@@ -117,7 +119,7 @@ const hasToken = token.length > 0 && !tokenError;
       setTimeout(() => window.location.assign("/signin"), 1500);
     } catch (err) {
       console.error("password reset failed", err);
-      showError("something went wrong. please try again.");
+      showError(authUnavailable("password reset"));
     } finally {
       submitBtn.disabled = false;
       submitBtn.textContent = original;

--- a/platform/apps/web/src/pages/signin.astro
+++ b/platform/apps/web/src/pages/signin.astro
@@ -97,7 +97,7 @@ const justVerified = Astro.url.searchParams.get("verified") === "1";
 </Base>
 
 <script>
-  import { authClient } from "../lib/authClient";
+  import { authClient, authErrorMessage, authUnavailable } from "../lib/authClient";
 
   const card = document.querySelector<HTMLDivElement>(".auth-card");
   const form = document.querySelector<HTMLFormElement>("[data-auth-form]");
@@ -226,7 +226,7 @@ const justVerified = Astro.url.searchParams.get("verified") === "1";
           callbackURL: "/signin?verified=1"
         });
         if (res.error) {
-          showError(res.error.message || "could not create the account.");
+          showError(authErrorMessage(res.error, "registration", "could not create the account."));
           return;
         }
         // When email verification is required, sign-up creates the account but
@@ -242,14 +242,15 @@ const justVerified = Astro.url.searchParams.get("verified") === "1";
         const res = await authClient.signIn.email({ email, password });
         if (res.error) {
           // An unverified account is hard-blocked by Better Auth with
-          // EMAIL_NOT_VERIFIED (403). Surface a helpful message + a resend, not
-          // the generic "invalid password".
-          if (res.error.code === "EMAIL_NOT_VERIFIED" || res.error.status === 403) {
+          // EMAIL_NOT_VERIFIED (403). Match the code only: any other 403 (a bad
+          // Origin, an edge block) is a server fault, not "verify your email"
+          // (field 2026-09-11).
+          if (res.error.code === "EMAIL_NOT_VERIFIED") {
             pendingEmail = email;
             showError("your email isn't verified yet -- check your inbox for the link.");
             showResend();
           } else {
-            showError(res.error.message || "invalid email or password.");
+            showError(authErrorMessage(res.error, "sign-in", "invalid email or password."));
           }
           return;
         }
@@ -258,7 +259,7 @@ const justVerified = Astro.url.searchParams.get("verified") === "1";
       window.location.assign(destination());
     } catch (err) {
       console.error("auth submit failed", err);
-      showError("something went wrong. please try again.");
+      showError(authUnavailable(mode === "register" ? "registration" : "sign-in"));
     } finally {
       submitBtn.disabled = false;
       submitBtn.textContent = original;
@@ -268,10 +269,13 @@ const justVerified = Astro.url.searchParams.get("verified") === "1";
   githubBtn?.addEventListener("click", async () => {
     clearError();
     try {
-      await authClient.signIn.social({
+      const res = await authClient.signIn.social({
         provider: "github",
         callbackURL: destination()
       });
+      if (res.error) {
+        showError(authErrorMessage(res.error, "GitHub sign-in", "GitHub sign-in failed. please try again."));
+      }
     } catch (err) {
       console.error("github sign-in failed", err);
       showError("GitHub sign-in failed. please try again.");
@@ -284,14 +288,20 @@ const justVerified = Astro.url.searchParams.get("verified") === "1";
     const original = resendBtn.textContent;
     resendBtn.textContent = "sending...";
     try {
-      await authClient.sendVerificationEmail({
+      const res = await authClient.sendVerificationEmail({
         email: pendingEmail,
         callbackURL: `${window.location.origin}/signin?verified=1`
       });
+      if (res.error) {
+        clearNotice(); // a stale "re-sent" notice must not sit beside the error
+        showError(authErrorMessage(res.error, "email verification", "could not resend right now. please try again."));
+        return;
+      }
       showNotice(`Verification link re-sent to ${pendingEmail}. Check your inbox.`);
       showResend();
     } catch (err) {
       console.error("resend verification failed", err);
+      clearNotice();
       showError("could not resend right now. please try again.");
     } finally {
       resendBtn.disabled = false;

--- a/platform/apps/web/src/server/seed.sql
+++ b/platform/apps/web/src/server/seed.sql
@@ -22,12 +22,14 @@ CREATE VIRTUAL TABLE specimens_fts USING fts5(
 DELETE FROM scans WHERE version_id IN (SELECT v.id FROM specimen_versions v JOIN specimens s ON s.id = v.specimen_id WHERE s.slug IN ('layered-noise-field', 'infinite-zoom-tunnel', 'curl-noise-swarm', 'spectrum-reactor', 'signed-distance-lantern', 'bloom-grade-stack', 'ev', 'clean2', 'ff', 'clean-net', 'evil'));
 DELETE FROM specimen_tags WHERE specimen_id IN (SELECT id FROM specimens WHERE slug IN ('layered-noise-field', 'infinite-zoom-tunnel', 'curl-noise-swarm', 'spectrum-reactor', 'signed-distance-lantern', 'bloom-grade-stack', 'ev', 'clean2', 'ff', 'clean-net', 'evil'));
 DELETE FROM specimen_versions WHERE specimen_id IN (SELECT id FROM specimens WHERE slug IN ('layered-noise-field', 'infinite-zoom-tunnel', 'curl-noise-swarm', 'spectrum-reactor', 'signed-distance-lantern', 'bloom-grade-stack', 'ev', 'clean2', 'ff', 'clean-net', 'evil'));
+DELETE FROM specimen_categories WHERE specimen_id IN (SELECT id FROM specimens WHERE slug IN ('layered-noise-field', 'infinite-zoom-tunnel', 'curl-noise-swarm', 'spectrum-reactor', 'signed-distance-lantern', 'bloom-grade-stack', 'ev', 'clean2', 'ff', 'clean-net', 'evil'));
 DELETE FROM specimens WHERE slug IN ('layered-noise-field', 'infinite-zoom-tunnel', 'curl-noise-swarm', 'spectrum-reactor', 'signed-distance-lantern', 'bloom-grade-stack', 'ev', 'clean2', 'ff', 'clean-net', 'evil');
 
 -- Purge any prior copy of these real specimens (clean re-run).
 DELETE FROM scans WHERE version_id IN (SELECT id FROM specimen_versions WHERE specimen_id IN ('sp-murmuration', 'sp-reaction-diffusion', 'sp-kaleidoscope', 'sp-noise-terrain', 'sp-plasma-interference', 'sp-mandelbulb-march'));
 DELETE FROM specimen_tags WHERE specimen_id IN ('sp-murmuration', 'sp-reaction-diffusion', 'sp-kaleidoscope', 'sp-noise-terrain', 'sp-plasma-interference', 'sp-mandelbulb-march');
 DELETE FROM specimen_versions WHERE specimen_id IN ('sp-murmuration', 'sp-reaction-diffusion', 'sp-kaleidoscope', 'sp-noise-terrain', 'sp-plasma-interference', 'sp-mandelbulb-march');
+DELETE FROM specimen_categories WHERE specimen_id IN ('sp-murmuration', 'sp-reaction-diffusion', 'sp-kaleidoscope', 'sp-noise-terrain', 'sp-plasma-interference', 'sp-mandelbulb-march');
 DELETE FROM specimens WHERE id IN ('sp-murmuration', 'sp-reaction-diffusion', 'sp-kaleidoscope', 'sp-noise-terrain', 'sp-plasma-interference', 'sp-mandelbulb-march');
 
 -- Tags (deduped across all specimens).
@@ -58,7 +60,7 @@ INSERT OR REPLACE INTO tags (id, name, slug) VALUES
 
 -- Specimens (real first-party metadata from specimens/manifest.json).
 INSERT OR REPLACE INTO specimens (
-  id, slug, author_id, title, description, category, difficulty, requires, op_count,
+  id, slug, author_id, title, description, category, level, requires, op_count,
   family_summary, current_version_id, thumbnail_key, license, visibility, tier, scan_status,
   capability_json, likes_count, views_count, copies_count
 ) VALUES
@@ -278,3 +280,9 @@ FROM specimens WHERE id = 'sp-plasma-interference';
 INSERT OR REPLACE INTO specimens_fts (rowid, slug, title, description, tags, author_handle, dat_text)
 SELECT rowid, 'mandelbulb-march', 'Mandelbulb March', 'A raymarched 3D Mandelbulb fractal rendered entirely in one GLSL TOP. The classic distance estimator is marched per pixel against a slowly orbiting camera; orbit-trap values captured during iteration tint the surface, and soft shadows, a fresnel rim, and a proximity glow give it depth. No input, no feedback - a drop-in hero render, a looping VJ source, or a reference for distance-estimated raymarching.', 'raymarching sdf glsl fractal 3d mandelbulb', 'envoy', 'glslTOP'
 FROM specimens WHERE id = 'sp-mandelbulb-march';
+
+-- Category membership (multi). Seed the join table from each specimen's primary
+-- category so the collection facet filter (which reads specimen_categories) and
+-- the category facets list include the seeded rows. Mirrors migration 0010.
+INSERT OR IGNORE INTO specimen_categories (specimen_id, category)
+SELECT id, category FROM specimens WHERE category IS NOT NULL AND category <> '';

--- a/platform/packages/tdxn-viewer/src/TdxnViewer.tsx
+++ b/platform/packages/tdxn-viewer/src/TdxnViewer.tsx
@@ -20,7 +20,7 @@ import {
   type NodeTypes,
   type ReactFlowInstance
 } from "@xyflow/react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 import type { GraphAnnotation, GraphNode, NormalizedGraph, RGB } from "@embody/contracts";
 import { operatorsAtLevel, parseTDXN, parseTDXNLevel } from "./parseTDXN";
@@ -122,8 +122,6 @@ type OperatorNodeData = {
   /** True when this is a COMP with a sub-network to drill into (navigable view
       only). Drives the clickable cursor + hover state. */
   canEnter: boolean;
-  /** True when this op is the current selection (drives the highlight ring). */
-  selected: boolean;
 };
 
 // Fallback node footprint, used only when an operator (and its type default)
@@ -162,6 +160,12 @@ const FAMILY_COLORS: Record<string, string> = {
   COMP: "#9aa1a8", // TD #303030 -- neutral grey (lifted for legibility)
   OBJECT: "#b9b09d" // fallback for any unrecognized family
 };
+
+// Selected op id, read by OperatorTile for the highlight ring. Kept OUT of node
+// data: a new node object drops React Flow's measured size, hiding every tile
+// for a frame, so the 2nd click of a double-click fell through to the
+// annotation behind and never entered the COMP (field 2026-09-11).
+const SelectedOpContext = createContext<string | null>(null);
 
 const NODE_TYPES: NodeTypes = {
   annotation: memo(AnnotationBox),
@@ -343,17 +347,6 @@ export function TdxnViewer({
   useEffect(() => {
     selectedIdRef.current = selectedId;
   }, [selectedId]);
-
-  // Tag the selected operator so OperatorTile can draw the highlight ring.
-  const selectedNodes = useMemo(
-    () =>
-      nodes.map((node) =>
-        node.type === "operator"
-          ? { ...node, data: { ...node.data, selected: node.id === selectedId } }
-          : node
-      ),
-    [nodes, selectedId]
-  );
 
   const style = useMemo<CSSProperties>(
     () => ({
@@ -547,50 +540,52 @@ export function TdxnViewer({
           ))}
         </nav>
       )}
-      <ReactFlow
-        nodes={selectedNodes}
-        edges={edges}
-        nodeTypes={NODE_TYPES}
-        edgeTypes={EDGE_TYPES}
-        proOptions={{ hideAttribution: true }}
-        onInit={(instance) => {
-          rfRef.current = instance;
-        }}
-        onNodeClick={navigable ? handleNodeClick : undefined}
-        onNodeDoubleClick={navigable ? handleNodeDoubleClick : undefined}
-        onPaneClick={navigable ? handlePaneClick : undefined}
-        fitView
-        fitViewOptions={{ padding: fitPadding }}
-        minZoom={0.12}
-        maxZoom={1.8}
-        nodesDraggable={false}
-        nodesConnectable={false}
-        elementsSelectable={false}
-        selectNodesOnDrag={false}
-        panOnDrag
-        panOnScroll
-        zoomOnScroll
-        zoomOnPinch
-        zoomOnDoubleClick={false}
-        onlyRenderVisibleElements
-        preventScrolling
-      >
-        {/* A single, very faint line grid -- subtle/minimalist, and (being a
-            React Flow Background) it pans AND zooms with the network like TD. */}
-        <Background
-          variant={BackgroundVariant.Lines}
-          gap={32}
-          lineWidth={1}
-          color="rgba(200, 208, 201, 0.035)"
-        />
-        {!fullscreen && (
-          <Controls position="top-right" showZoom={false} showFitView={false} showInteractive={false}>
-            <ControlButton onClick={() => setFullscreen(true)} title="View fullscreen" aria-label="View fullscreen">
-              {expandIcon}
-            </ControlButton>
-          </Controls>
-        )}
-      </ReactFlow>
+      <SelectedOpContext.Provider value={selectedId}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={NODE_TYPES}
+          edgeTypes={EDGE_TYPES}
+          proOptions={{ hideAttribution: true }}
+          onInit={(instance) => {
+            rfRef.current = instance;
+          }}
+          onNodeClick={navigable ? handleNodeClick : undefined}
+          onNodeDoubleClick={navigable ? handleNodeDoubleClick : undefined}
+          onPaneClick={navigable ? handlePaneClick : undefined}
+          fitView
+          fitViewOptions={{ padding: fitPadding }}
+          minZoom={0.12}
+          maxZoom={1.8}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          selectNodesOnDrag={false}
+          panOnDrag
+          panOnScroll
+          zoomOnScroll
+          zoomOnPinch
+          zoomOnDoubleClick={false}
+          onlyRenderVisibleElements
+          preventScrolling
+        >
+          {/* A single, very faint line grid -- subtle/minimalist, and (being a
+              React Flow Background) it pans AND zooms with the network like TD. */}
+          <Background
+            variant={BackgroundVariant.Lines}
+            gap={32}
+            lineWidth={1}
+            color="rgba(200, 208, 201, 0.035)"
+          />
+          {!fullscreen && (
+            <Controls position="top-right" showZoom={false} showFitView={false} showInteractive={false}>
+              <ControlButton onClick={() => setFullscreen(true)} title="View fullscreen" aria-label="View fullscreen">
+                {expandIcon}
+              </ControlButton>
+            </Controls>
+          )}
+        </ReactFlow>
+      </SelectedOpContext.Provider>
       {fullscreen && (
         <button
           type="button"
@@ -605,14 +600,15 @@ export function TdxnViewer({
   );
 }
 
-function OperatorTile({ data }: NodeProps<OperatorNode>) {
+function OperatorTile({ id, data }: NodeProps<OperatorNode>) {
+  const selected = useContext(SelectedOpContext) === id;
   const inputHandles = Array.from({ length: Math.max(data.inputCount, 1) }, (_, index) => index);
   const compHandles = Array.from({ length: data.compInputCount }, (_, index) => index);
 
   const className = [
     "tdxn-operator",
     data.canEnter ? "tdxn-operator--enterable" : "",
-    data.selected ? "tdxn-operator--selected" : ""
+    selected ? "tdxn-operator--selected" : ""
   ]
     .filter(Boolean)
     .join(" ");
@@ -777,9 +773,7 @@ function toFlowElements(
         isRefTarget: refTargets.has(node.id),
         // childCount is only set by the single-level parse, so canEnter is
         // naturally false in the flattened (non-navigable) view.
-        canEnter: (node.childCount ?? 0) > 0,
-        // Set per-render by the selectedNodes memo in TdxnViewer.
-        selected: false
+        canEnter: (node.childCount ?? 0) > 0
       },
       draggable: false,
       selectable: false


### PR DESCRIPTION
The Playwright e2e suite now runs in CI and gates every embody.tools deploy, and a smoke check runs against production after each deploy.

**Why:** #105 carried a Dependabot bump of better-auth that returned 500 on every auth request for about 23.5 hours (hotfix #111). A TDN -> TDXN rename had already broken specimen submit for 4 days (hotfix #112). Before this PR, CI only ran the type check, the build and the scanner unit tests before auto-deploying, so neither break was caught. The e2e suite catches both: without #111, global setup fails with `admin sign-up failed: 500`, and without #112 the contribute tests get 400 `tdn is required.`

**CI** (`.github/workflows/platform-ci.yml`)
- New `e2e` job, run on every push and PR touching `platform/**` or `specimens/**`. On a fresh runner it applies the local D1 migrations, seeds local R2 after checking each blob's sha256 against `seed.sql`, warms the Vite cache, and runs the full suite.
- `deploy` now needs `e2e`. Its existing `if:` is unchanged.
- The post-deploy smoke waits for the new version to reach the edge. It then requires `GET /api/auth/get-session` to return 200 `null` and a sign-in for an unknown address to return 401 `INVALID_EMAIL_OR_PASSWORD`, twice, 30 s apart. On failure it points to `wrangler rollback`. It never signs up or sends mail.

**Suite fixes** (8 specs failed on a clean database)
- `seed.sql` had lost the `difficulty` -> `level` rename and the category rows when it was regenerated in August, so setup failed on any fresh DB. The generator is fixed and `seed.sql` regenerated.
- The collection specs expected stale seed data. They now read the expected sha256 and size from `seed.sql`.
- Viewer bug, live since June: every selection hid all tiles for one frame, so a fast double-click missed the COMP. Fixed in `TdxnViewer.tsx`. The spec fails 3/3 against the old viewer.
- The submit rate limiter is off in development only, like its sibling limiters. Otherwise the suite gets a 429 on its 11th submit. Production is unchanged.

**Auth pages**
- 5xx and network failures now read "... is unavailable right now", not "invalid email or password." (which is what users saw during the outage).
- Only the `EMAIL_NOT_VERIFIED` code shows "verify your email". Any other 403 is treated as a server fault.
- Resend-verification no longer reports success on a failure, and no stale "re-sent" notice is left next to an error.

**New tests:** stubbed outages for every auth page, an auth API canary, the forgot-password happy path, submitting a real Embody `.tdxn`, replacing a network from the edit page, and pasting an Embody clipboard envelope with Ctrl+V and with the toolbar button.

**Verified locally** from a clean state, running each step script exactly as written in the YAML:
- Full suite: 51 passed, 0 failed, 0 flaky, in 4.1 min.
- `astro check`: 0 errors. `astro build`: OK. scanner-ts: 99/99.
- zizmor and actionlint: clean.
- The new smoke script ran against production and passed both rounds.
- Reviewed by a 5-lens panel (runtime, spec, correctness, security, CI resilience). All three blocking findings were fixed and re-reviewed.

**Notes for merging**
- Don't make `e2e` a required status check in branch protection. The workflow is path-filtered, so PRs that don't touch `platform/**` would sit in Pending forever. The deploy gate works through `needs:` regardless.
- Specimen re-exports now trigger this workflow. A re-export changes the file bytes, so regenerate the seed data in the same commit: `python3 platform/apps/web/scripts/build-specimen-data.py`.
- Still unverified until this PR's own CI run: the Linux runner path (apt deps, warm-up, port handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
