### PR TITLE
Release flow: block on outstanding GitHub items before every release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,11 +1,26 @@
 ---
 name: release
-description: MUST READ before preparing a release commit or GitHub release -- project.save() versioning, changelog, README, template sync verification, fresh-install smoke, and the post-push GitHub release procedure (references/github-release.md).
+description: MUST READ before preparing a release commit or GitHub release -- the blocking GitHub preflight (dev/release_preflight.py), project.save() versioning, changelog, README, template sync verification, fresh-install smoke, and the post-push GitHub release procedure (references/github-release.md).
 ---
 
 # Release Commit Procedure
 
 When the user asks to prepare a release commit (e.g., "prep a commit for v217"), follow these steps in order. After a successful push, follow `references/github-release.md` for the GitHub release.
+
+## Preflight: nothing outstanding on GitHub (blocking, before step 0)
+
+Run this from the release checkout (the repo root, on `dev`) before anything else, and again right before the push (`python3` on macOS):
+
+```
+python dev/release_preflight.py
+```
+
+- **BLOCKING:** open Dependabot, code-scanning or secret-scanning alerts; draft or triage security advisories (private vulnerability reports); open Dependabot PRs; a red latest push-CI run of any workflow on `main` or `dev`; a failed third-party check on either tip; real commits on `main` that the release checkout lacks (a hotfix never merged back: merge `origin/main` in and push). A check it cannot run also blocks, so a failed API call never reads as "nothing open".
+- **WARNING:** other open PRs, every open issue (tagged NEW since the last release), merged branches left on the remote.
+- **Exit 1 = STOP.** Show the user every item. Each blocker gets resolved (a Dependabot PR merged only after its platform e2e run is green, or closed; alerts fixed or dismissed with a reason; hotfixes back-merged) or the user explicitly accepts it. Only then re-run with `--ack "<key>"`, and only for keys the user named. Never ack on your own judgment.
+- **Report the warnings in the same message.** List any acked items in the release commit body so the decision is on record.
+
+Why: on 2026-09-11 embody.tools sign-in was down ~23h after a dependency bump (PR #105) and specimen submit had been broken 4 days by a rename; two hotfixes then sat on `main` without `dev`. The preflight keeps outstanding GitHub state from being skipped; the platform e2e gate is what catches a breaking bump.
 
 ## 0. Save the Project
 
@@ -238,7 +253,8 @@ with a red row is the failure mode this step exists to end.
   ```
   Embody vX.Y.Z: <comma-separated themes>
   ```
-- Do NOT push unless the user asks.
+- Add any preflight items the user accepted (`--ack`) to the commit body.
+- Do NOT push unless the user asks. Re-run the preflight immediately before the push; it must exit 0.
 
 ## 7. Publish the Docs (`main` only)
 

--- a/.claude/skills/release/references/github-release.md
+++ b/.claude/skills/release/references/github-release.md
@@ -88,4 +88,5 @@ gh release create TAG ASSET_FILES... \
   the PR ref, and main had all passed the same code, and it went unnoticed
   until the user asked. A red tag run needs the same immediate triage as a
   red branch run.
+- **Re-run `python dev/release_preflight.py` once the branch runs finish** (it reads `main`/`dev` push runs, not the tag runs watched above). It must exit 0, and its warnings go in the report too.
 - Report the release URL to the user.

--- a/.github/workflows/bridge-tests.yml
+++ b/.github/workflows/bridge-tests.yml
@@ -47,6 +47,9 @@ on:
       - 'dev/embody/unit_tests/test_project_saved_gate.py'
       - 'dev/embody/unit_tests/test_promoted_surface.py'
       - 'dev/embody/unit_tests/test_release_toe.py'
+      - 'dev/embody/unit_tests/test_release_preflight.py'
+      - 'dev/release_preflight.py'
+      - 'dev/embody/unit_tests/test_tdxn_par_key_migration.py'
       # The promoted-surface census reads the extension sources and the
       # caller index, so a change to either must trigger it.
       - 'dev/embody/Embody/**/*.py'
@@ -104,6 +107,9 @@ on:
       - 'dev/embody/unit_tests/test_project_saved_gate.py'
       - 'dev/embody/unit_tests/test_promoted_surface.py'
       - 'dev/embody/unit_tests/test_release_toe.py'
+      - 'dev/embody/unit_tests/test_release_preflight.py'
+      - 'dev/release_preflight.py'
+      - 'dev/embody/unit_tests/test_tdxn_par_key_migration.py'
       # The promoted-surface census reads the extension sources and the
       # caller index, so a change to either must trigger it.
       - 'dev/embody/Embody/**/*.py'

--- a/dev/embody/unit_tests/test_release_preflight.py
+++ b/dev/embody/unit_tests/test_release_preflight.py
@@ -1,0 +1,227 @@
+"""release_preflight: the GitHub outstanding-items gate at the top of the /release flow.
+
+Pure stdlib, and deliberately no module-level pytest import: TestRunnerExt
+imports every test_*.py under TD's Python, which has no pytest. gh and git are
+replaced by a scripted runner, so every verdict (block, warn, ack, fail-closed)
+is pinned without network access (field 2026-09-11).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[2] / "release_preflight.py"
+_spec = importlib.util.spec_from_file_location("release_preflight", _PATH)
+rp = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = rp  # @dataclass resolves its module via sys.modules
+_spec.loader.exec_module(rp)
+
+REPO = "owner/repo"
+
+
+def _run(conclusion="success", status="completed", at="2026-09-11T10:00:00Z"):
+    return {"status": status, "conclusion": conclusion, "url": "u", "createdAt": at}
+
+
+class FakeRunner:
+    """Routes each gh/git argv to a scripted response; an Exception value raises."""
+
+    def __init__(self, **overrides):
+        self.responses = {
+            "dependabot": [], "code-scanning": [], "secret-scanning": [],
+            "advisory-triage": [], "advisory-draft": [],
+            "prs": [], "workflows": [{"id": 1, "name": "Platform CI", "state": "active"}],
+            "runs:main:1": [_run()], "runs:dev:1": [_run()],
+            "checks:main": {"check_runs": []}, "checks:dev": {"check_runs": []},
+            "release": {"tagName": "v1.0.0", "publishedAt": "2026-09-01T00:00:00Z"},
+            "issues": [], "fetch": "", "head": "dev\n", "drift": "",
+            "branches": "  origin/HEAD -> origin/main\n  origin/main\n  origin/dev\n",
+        }
+        self.responses.update(overrides)
+        self.calls = []
+
+    def _route(self, cmd):
+        joined = " ".join(cmd)
+        if cmd[:2] == ["gh", "api"]:
+            for kind in ("dependabot", "code-scanning", "secret-scanning"):
+                if f"/{kind}/alerts" in joined:
+                    return kind
+            if "/security-advisories" in joined:
+                return "advisory-triage" if "state=triage" in joined else "advisory-draft"
+            if "/check-runs" in joined:
+                return "checks:" + joined.split("/commits/")[1].split("/")[0]
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return "prs"
+        if cmd[:3] == ["gh", "workflow", "list"]:
+            return "workflows"
+        if cmd[:3] == ["gh", "run", "list"]:
+            return f"runs:{cmd[cmd.index('--branch') + 1]}:{cmd[cmd.index('--workflow') + 1]}"
+        if cmd[:3] == ["gh", "release", "view"]:
+            return "release"
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return "issues"
+        if cmd[:2] == ["git", "fetch"]:
+            return "fetch"
+        if cmd[:2] == ["git", "rev-parse"]:
+            return "head"
+        if cmd[:2] == ["git", "log"]:
+            return "drift"
+        if cmd[:2] == ["git", "branch"]:
+            return "branches"
+        raise AssertionError(f"unrouted command: {joined}")
+
+    def __call__(self, cmd):
+        self.calls.append(list(cmd))
+        val = self.responses.get(self._route(cmd), [])
+        if isinstance(val, Exception):
+            raise val
+        return val if isinstance(val, str) else json.dumps(val)
+
+
+def _main(capsys, runner, *extra):
+    code = rp.main(["--repo", REPO, *extra], runner=runner)
+    return code, capsys.readouterr().out
+
+
+def test_all_clear_exits_zero(capsys):
+    code, out = _main(capsys, FakeRunner())
+    assert code == 0
+    assert "BLOCKING (0)" in out and "RESULT: CLEAR" in out
+
+
+def test_open_dependabot_pr_blocks_until_user_acks(capsys):
+    pr = {"number": 113, "title": "deps: bump better-auth", "author": {"login": "app/dependabot", "is_bot": True},
+          "url": "u", "isDraft": False, "createdAt": "2026-09-10T00:00:00Z"}
+    code, out = _main(capsys, FakeRunner(prs=[pr]))
+    assert code == 1 and "[pr:113] open Dependabot PR" in out
+    code, out = _main(capsys, FakeRunner(prs=[pr]), "--ack", "pr:113")
+    assert code == 0 and "ACKED [pr:113]" in out
+
+
+def test_human_pr_and_issues_warn_but_do_not_block(capsys):
+    pr = {"number": 44, "title": "Basic git hooks", "author": {"login": "ulgens"}, "url": "u",
+          "isDraft": False, "createdAt": "2026-07-09T00:00:00Z"}
+    issues = [{"number": 110, "title": "new bug", "url": "u", "createdAt": "2026-09-11T09:00:00Z"},
+              {"number": 36, "title": "old ask", "url": "u", "createdAt": "2026-07-09T00:00:00Z"}]
+    code, out = _main(capsys, FakeRunner(prs=[pr], issues=issues))
+    assert code == 0
+    assert "[pr:44] open PR by ulgens" in out
+    assert "#110 NEW since v1.0.0" in out and "#36:" in out and "#36 NEW" not in out
+
+
+def test_every_open_security_alert_kind_blocks(capsys):
+    alert = {"number": 7, "html_url": "u", "security_advisory": {"severity": "high", "summary": "s"},
+             "dependency": {"package": {"name": "sharp"}}, "rule": {"id": "r"}, "secret_type_display_name": "t"}
+    for kind in ("dependabot", "code-scanning", "secret-scanning"):
+        code, out = _main(capsys, FakeRunner(**{kind: [alert]}))
+        assert code == 1 and f"[alert:{kind}:7]" in out, kind
+
+
+def test_private_vulnerability_report_blocks(capsys):
+    adv = {"ghsa_id": "GHSA-abcd-efgh-ijkl", "state": "triage", "severity": "high", "summary": "rce", "html_url": "u"}
+    code, out = _main(capsys, FakeRunner(**{"advisory-triage": [adv]}))
+    assert code == 1 and "[advisory:GHSA-abcd-efgh-ijkl]" in out
+
+
+def test_alert_and_pr_queries_ask_for_open_items_only(capsys):
+    runner = FakeRunner()
+    _main(capsys, runner)
+    apis = [" ".join(c) for c in runner.calls if c[:2] == ["gh", "api"]]
+    for kind in ("dependabot", "code-scanning", "secret-scanning"):
+        assert any(f"/{kind}/alerts?state=open" in a for a in apis), kind
+    assert any("security-advisories?state=triage" in a for a in apis)
+    assert any("security-advisories?state=draft" in a for a in apis)
+    pr_call = next(c for c in runner.calls if c[:3] == ["gh", "pr", "list"])
+    assert pr_call[pr_call.index("--state") + 1] == "open"
+
+
+def test_unreachable_or_malformed_alert_feed_fails_closed(capsys):
+    # A 403/404 or an odd payload must never read as "zero alerts".
+    code, out = _main(capsys, FakeRunner(dependabot=rp.CheckError("gh api failed: HTTP 403")))
+    assert code == 1 and "[verify:dependabot]" in out
+    code, out = _main(capsys, FakeRunner(**{"secret-scanning": {"message": "Not Found"}}))
+    assert code == 1 and "[verify:secret-scanning]" in out
+
+
+def test_red_latest_ci_blocks_but_a_superseded_failure_does_not(capsys):
+    for conclusion in ("failure", "cancelled", "timed_out"):
+        code, out = _main(capsys, FakeRunner(**{"runs:main:1": [_run(conclusion)]}))
+        assert code == 1 and "[ci:main:Platform CI]" in out, conclusion
+    healed = FakeRunner(**{"runs:main:1": [_run("failure", at="2026-09-11T09:00:00Z"),
+                                           _run("success", at="2026-09-11T10:00:00Z")]})
+    code, _ = _main(capsys, healed)
+    assert code == 0
+
+
+def test_ci_is_queried_per_workflow_and_push_only(capsys):
+    runner = FakeRunner()
+    _main(capsys, runner)
+    run_calls = [c for c in runner.calls if c[:3] == ["gh", "run", "list"]]
+    assert {c[c.index("--branch") + 1] for c in run_calls} == {"main", "dev"}
+    for c in run_calls:
+        assert c[c.index("--event") + 1] == "push" and "--workflow" in c
+
+
+def test_in_progress_ci_warns_unless_the_last_finished_run_was_red(capsys):
+    busy = [_run(conclusion="", status="in_progress", at="2026-09-11T11:00:00Z")]
+    code, out = _main(capsys, FakeRunner(**{"runs:dev:1": busy}))
+    assert code == 0 and "still in_progress" in out
+    code, out = _main(capsys, FakeRunner(**{"runs:dev:1": busy + [_run("failure")]}))
+    assert code == 1 and "last finished run is failure" in out
+
+
+def test_a_branch_with_no_push_runs_fails_closed(capsys):
+    code, out = _main(capsys, FakeRunner(**{"runs:dev:1": []}))
+    assert code == 1 and "[verify:ci:dev]" in out
+
+
+def test_failed_third_party_check_on_a_tip_blocks(capsys):
+    checks = {"check_runs": [
+        {"name": "Workers Builds: x", "conclusion": "failure", "app": {"slug": "cloudflare-workers-and-pages"}, "html_url": "u"},
+        {"name": "e2e", "conclusion": "failure", "app": {"slug": "github-actions"}, "html_url": "u"},
+    ]}
+    code, out = _main(capsys, FakeRunner(**{"checks:main": checks}))
+    assert code == 1 and "[check:main:Workers Builds: x]" in out and "[check:main:e2e]" not in out
+
+
+def test_main_commits_missing_from_the_release_checkout_block(capsys):
+    runner = FakeRunner(drift="b20bf5e0 Fix login\n5b12ca0f Fix submit\n")
+    code, out = _main(capsys, runner)
+    assert code == 1 and "2 commit(s) on main are missing from dev" in out
+    log_cmd = next(c for c in runner.calls if c[:2] == ["git", "log"])
+    # Right side = main, left = the release checkout; merge commits never count.
+    assert log_cmd[-1] == "HEAD...origin/main"
+    for flag in ("--no-merges", "--cherry-pick", "--right-only"):
+        assert flag in log_cmd, flag
+
+
+def test_merged_remote_branch_warns(capsys):
+    code, out = _main(capsys, FakeRunner(branches="  origin/main\n  origin/dev\n  origin/hotfix/x\n"))
+    assert code == 0 and "[branch:hotfix/x]" in out and "[branch:dev]" not in out
+
+
+def test_failed_git_fetch_fails_closed(capsys):
+    code, out = _main(capsys, FakeRunner(fetch=rp.CheckError("git fetch failed")))
+    assert code == 1 and "[verify:git]" in out
+
+
+def test_missing_tool_is_a_check_error_not_a_traceback():
+    try:
+        rp.run(["embody-no-such-tool-xyz", "--version"])
+    except rp.CheckError as exc:
+        assert "embody-no-such-tool-xyz" in str(exc)
+    else:
+        raise AssertionError("expected CheckError")
+
+
+def test_no_release_yet_only_drops_the_new_tags(capsys):
+    issues = [{"number": 5, "title": "t", "url": "u", "createdAt": "2026-09-11T00:00:00Z"}]
+    code, out = _main(capsys, FakeRunner(release=rp.CheckError("release not found"), issues=issues))
+    assert code == 0 and "[issue:5]" in out and "NEW" not in out.split("[issue:5]")[1].split("\n")[0]
+
+
+def test_ack_that_matches_nothing_is_reported(capsys):
+    code, out = _main(capsys, FakeRunner(), "--ack", "pr:999")
+    assert code == 0 and "--ack pr:999 matched nothing" in out

--- a/dev/release_preflight.py
+++ b/dev/release_preflight.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Release preflight: nothing outstanding on GitHub before an Embody release.
+
+BLOCKING: open Dependabot / code-scanning / secret-scanning alerts, draft or
+triage security advisories (private vulnerability reports), open Dependabot
+PRs, a red latest push-CI run per workflow on main or dev, a failed
+third-party check on either tip, and real commits on main that the release
+checkout (HEAD) lacks. WARNING: other open PRs, open issues (tagged NEW since
+the last release), merged branches left on the remote. Fails CLOSED: a check
+that cannot run is itself a blocker.
+
+It makes outstanding GitHub state visible and blocking; it does not test the
+product -- the platform e2e gate does that (field 2026-09-11).
+
+Usage:  python dev/release_preflight.py [--ack KEY[,KEY...]] [--repo OWNER/NAME]
+Exit:   0 = clear, or every blocker acknowledged by the user; 1 = blocked.
+Needs:  an authenticated gh CLI and git, run from the release checkout.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence
+
+Runner = Callable[[Sequence[str]], str]
+
+RED_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required", "startup_failure"}
+KEPT_BRANCHES = {"main", "dev", "HEAD", "gh-pages"}
+DEPENDABOT_LOGINS = {"app/dependabot", "dependabot", "dependabot[bot]"}
+CI_BRANCHES = ("main", "dev")
+TIMEOUT_S = 120
+
+
+class CheckError(Exception):
+    """A check could not run. The preflight reports it as a blocker."""
+
+
+@dataclass
+class Finding:
+    level: str  # "block" or "warn"
+    key: str    # stable id for --ack, e.g. "pr:113"
+    text: str
+
+
+def run(cmd: Sequence[str]) -> str:
+    env = dict(os.environ, GIT_TERMINAL_PROMPT="0", GH_PROMPT_DISABLED="1")
+    try:
+        proc = subprocess.run(list(cmd), capture_output=True, text=True, encoding="utf-8", errors="replace",
+                              stdin=subprocess.DEVNULL, timeout=TIMEOUT_S, env=env)
+    except (OSError, subprocess.TimeoutExpired) as exc:  # missing tool, or a hung fetch
+        raise CheckError(f"{cmd[0]}: {exc}") from exc
+    if proc.returncode != 0:
+        lines = [ln.strip() for ln in (proc.stderr or proc.stdout or "").splitlines() if ln.strip()]
+        raise CheckError(" ".join(cmd[:3]) + " failed: " + (" | ".join(lines[:2])[:300] or f"exit {proc.returncode}"))
+    return proc.stdout
+
+
+def gh_json(runner: Runner, args: Sequence[str]):
+    out = runner(["gh", *args])
+    try:
+        return json.loads(out) if out.strip() else None
+    except json.JSONDecodeError as exc:
+        raise CheckError("gh " + " ".join(args[:2]) + ": unparseable output (" + str(exc) + ")") from exc
+
+
+def check_alerts(runner: Runner, repo: str) -> List[Finding]:
+    out: List[Finding] = []
+    feeds = [(k, f"repos/{repo}/{k}/alerts?state=open&per_page=100") for k in
+             ("dependabot", "code-scanning", "secret-scanning")]
+    feeds += [(f"advisory-{s}", f"repos/{repo}/security-advisories?state={s}&per_page=100") for s in ("triage", "draft")]
+    for kind, path in feeds:
+        try:
+            items = gh_json(runner, ["api", path])
+        except CheckError as exc:
+            out.append(Finding("block", f"verify:{kind}", f"could not read {kind}: {exc}"))
+            continue
+        if not isinstance(items, list):
+            out.append(Finding("block", f"verify:{kind}", f"unexpected {kind} response"))
+            continue
+        for a in items:
+            if kind == "dependabot":
+                adv = a.get("security_advisory") or {}
+                pkg = ((a.get("dependency") or {}).get("package") or {}).get("name", "?")
+                key, what = f"alert:dependabot:{a.get('number')}", f"{adv.get('severity', '?')} {pkg}: {adv.get('summary', '')}"
+            elif kind == "code-scanning":
+                rule = a.get("rule") or {}
+                loc = ((a.get("most_recent_instance") or {}).get("location") or {}).get("path", "?")
+                key, what = f"alert:code-scanning:{a.get('number')}", f"{rule.get('id', '?')} in {loc}"
+            elif kind == "secret-scanning":
+                key, what = f"alert:secret-scanning:{a.get('number')}", a.get("secret_type_display_name") or a.get("secret_type", "?")
+            else:
+                key = f"advisory:{a.get('ghsa_id')}"
+                what = f"{a.get('state')} {a.get('severity') or '?'}: {a.get('summary', '')}"
+            out.append(Finding("block", key, f"open {kind}: {what} {a.get('html_url', '')}"))
+    return out
+
+
+def check_prs(runner: Runner, repo: str) -> List[Finding]:
+    prs = gh_json(runner, ["pr", "list", "--repo", repo, "--state", "open", "--limit", "100",
+                           "--json", "number,title,author,url,isDraft,createdAt"]) or []
+    out: List[Finding] = []
+    for pr in prs:
+        login = (pr.get("author") or {}).get("login", "")
+        label = f"#{pr['number']} {pr.get('title', '')} (opened {pr.get('createdAt', '')[:10]}) {pr.get('url', '')}"
+        if login in DEPENDABOT_LOGINS:
+            out.append(Finding("block", f"pr:{pr['number']}", f"open Dependabot PR {label}"))
+        else:
+            draft = " [draft]" if pr.get("isDraft") else ""
+            out.append(Finding("warn", f"pr:{pr['number']}", f"open PR by {login}{draft} {label}"))
+    return out
+
+
+def check_ci(runner: Runner, repo: str) -> List[Finding]:
+    # Per workflow and push-only: a shared run window can drop a quiet red
+    # workflow, and PR/fork runs file under arbitrary branch names.
+    wfs = [w for w in (gh_json(runner, ["workflow", "list", "--repo", repo, "--all", "--json", "id,name,state"]) or [])
+           if w.get("state") == "active"]
+    if not wfs:
+        raise CheckError("no active workflows listed")
+    out: List[Finding] = []
+    for br in CI_BRANCHES:
+        seen = 0
+        for w in sorted(wfs, key=lambda w: w.get("name", "")):
+            runs = gh_json(runner, ["run", "list", "--repo", repo, "--workflow", str(w["id"]), "--branch", br,
+                                    "--event", "push", "--limit", "2", "--json", "status,conclusion,url,createdAt"]) or []
+            if not runs:
+                continue
+            seen += 1
+            runs = sorted(runs, key=lambda r: r.get("createdAt", ""), reverse=True)
+            last, key, name = runs[0], f"ci:{br}:{w['name']}", w["name"]
+            if last.get("status") != "completed":
+                prev = next((r for r in runs[1:] if r.get("status") == "completed"), None)
+                if prev and prev.get("conclusion") in RED_CONCLUSIONS:
+                    out.append(Finding("block", key, f"{name} on {br}: last finished run is {prev.get('conclusion')} "
+                                                     f"and the rerun is still {last.get('status')} {last.get('url', '')}"))
+                else:
+                    out.append(Finding("warn", key, f"{name} on {br} is still {last.get('status')}; wait for it {last.get('url', '')}"))
+            elif last.get("conclusion") in RED_CONCLUSIONS:
+                out.append(Finding("block", key, f"latest {name} push run on {br} is {last.get('conclusion')} {last.get('url', '')}"))
+        if not seen:
+            out.append(Finding("block", f"verify:ci:{br}", f"no push-triggered CI runs found on {br}; renamed branch or CI off?"))
+        # Third-party checks on the tip (e.g. Cloudflare Workers Builds) never appear in gh run list.
+        tip = gh_json(runner, ["api", f"repos/{repo}/commits/{br}/check-runs?per_page=100"]) or {}
+        for c in tip.get("check_runs", []):
+            if (c.get("app") or {}).get("slug") != "github-actions" and c.get("conclusion") in RED_CONCLUSIONS:
+                out.append(Finding("block", f"check:{br}:{c.get('name')}",
+                                   f"third-party check {c.get('name')} on the {br} tip is {c.get('conclusion')} {c.get('html_url', '')}"))
+    return out
+
+
+def check_git(runner: Runner, repo: str) -> List[Finding]:
+    runner(["git", "fetch", "--quiet", "--prune", "origin"])
+    out: List[Finding] = []
+    head = runner(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip() or "HEAD"
+    # Real changes only: a release merge (dev -> main) leaves a merge commit the
+    # release branch lacks, and a cherry-picked hotfix has a different sha.
+    missing = [ln for ln in runner(["git", "log", "--oneline", "--no-merges", "--cherry-pick", "--right-only",
+                                    "HEAD...origin/main"]).splitlines() if ln.strip()]
+    if missing:
+        shown = "; ".join(missing[:5]) + (" ..." if len(missing) > 5 else "")
+        out.append(Finding("block", "drift:main-not-in-release",
+                           f"{len(missing)} commit(s) on main are missing from {head}; merge origin/main into {head} "
+                           f"(and push it) first: {shown}"))
+    for line in runner(["git", "branch", "-r", "--merged", "origin/main"]).splitlines():
+        name = line.strip()
+        if not name or "->" in name:
+            continue
+        short = name.split("/", 1)[1] if name.startswith("origin/") else name
+        if short not in KEPT_BRANCHES:
+            out.append(Finding("warn", f"branch:{short}", f"remote branch {short} is merged into main; delete it"))
+    return out
+
+
+def check_issues(runner: Runner, repo: str) -> List[Finding]:
+    out: List[Finding] = []
+    try:
+        rel = gh_json(runner, ["release", "view", "--repo", repo, "--json", "tagName,publishedAt"]) or {}
+    except CheckError as exc:  # no release yet: issues still list, just untagged
+        rel = {}
+        out.append(Finding("warn", "verify:release", f"could not read the latest release, so NEW tags are off: {exc}"))
+    tag, since = rel.get("tagName", "?"), rel.get("publishedAt", "")
+    issues = gh_json(runner, ["issue", "list", "--repo", repo, "--state", "open", "--limit", "200",
+                              "--json", "number,title,url,createdAt"]) or []
+    for i in sorted(issues, key=lambda i: i.get("number", 0), reverse=True):
+        new = f" NEW since {tag}" if since and i.get("createdAt", "") >= since else ""
+        out.append(Finding("warn", f"issue:{i['number']}",
+                           f"open issue #{i['number']}{new}: {i.get('title', '')} {i.get('url', '')}"))
+    return out
+
+
+CHECKS = (check_alerts, check_prs, check_ci, check_git, check_issues)
+
+
+def collect(runner: Runner, repo: str) -> List[Finding]:
+    findings: List[Finding] = []
+    for check in CHECKS:
+        name = check.__name__.replace("check_", "")
+        try:
+            findings.extend(check(runner, repo))
+        except CheckError as exc:
+            findings.append(Finding("block", f"verify:{name}", f"could not run the {name} check: {exc}"))
+    return findings
+
+
+def main(argv: Optional[Sequence[str]] = None, runner: Runner = run) -> int:
+    ap = argparse.ArgumentParser(description="Embody release preflight: nothing outstanding on GitHub.")
+    ap.add_argument("--repo", help="OWNER/NAME for the gh checks (default: this checkout's gh repo); "
+                                   "the git checks always use this checkout")
+    ap.add_argument("--ack", action="append", default=[], metavar="KEY",
+                    help="blocker key the USER explicitly accepted; repeatable or comma-separated; quote keys with spaces")
+    args = ap.parse_args(argv)
+    try:
+        sys.stdout.reconfigure(errors="replace")  # PR titles can carry non-ASCII
+    except AttributeError:
+        pass
+
+    repo = args.repo
+    if not repo:
+        try:
+            repo = (gh_json(runner, ["repo", "view", "--json", "nameWithOwner"]) or {}).get("nameWithOwner")
+        except CheckError as exc:
+            print(f"RESULT: BLOCKED, cannot resolve the repo ({exc}); pass --repo OWNER/NAME")
+            return 1
+    acks = {k.strip() for a in args.ack for k in a.split(",") if k.strip()}
+    findings = collect(runner, repo)
+
+    blockers = [f for f in findings if f.level == "block"]
+    open_blockers = [f for f in blockers if f.key not in acks]
+    warnings = [f for f in findings if f.level == "warn"]
+    print(f"Embody release preflight: {repo}")
+    for title, items in (("BLOCKING", blockers), ("WARNING", warnings)):
+        print(f"{title} ({len(items)})")
+        for f in items:
+            tag = "ACKED " if f.key in acks else ""
+            print(f"  {tag}[{f.key}] {f.text}")
+    for key in sorted(acks - {f.key for f in findings}):
+        print(f"NOTE: --ack {key} matched nothing; check the key")
+    if open_blockers:
+        print(f"RESULT: BLOCKED by {len(open_blockers)} item(s). Resolve each one, or re-run with "
+              "--ack \"<key>\" for items the user explicitly accepted. Report every warning too.")
+        return 1
+    print(f"RESULT: CLEAR ({len(blockers)} acknowledged blocker(s), {len(warnings)} warning(s) to report)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pytest.ini
+++ b/pytest.ini
@@ -100,6 +100,10 @@ testpaths =
 ; 45-90 restores land) is silent and platform-independent, and shipping
 ; past it produces an artifact that looks fine and is hollow.
     dev/embody/unit_tests/test_release_toe.py
+; test_release_preflight.py: the /release flow gate on GitHub (open alerts,
+; Dependabot PRs, red CI, main commits missing from dev). Pure stdlib with a
+; scripted gh/git runner; it must fail closed on both legs (field 2026-09-11).
+    dev/embody/unit_tests/test_release_preflight.py
 ; Collection/tests: 63 tests on the UNTRUSTED-IMPORT path -- safe_import's
 ; opshortcut stripping, the capability scanner, TDXN envelope parsing. They are
 ; stdlib-only and run in 0.25s, and until 2026-08-29 they ran on ZERO runners:


### PR DESCRIPTION
Adds a blocking GitHub preflight to the `/release` flow, so outstanding items stop a release instead of being skipped.

**What:** `dev/release_preflight.py`, run before step 0, again right before the push, and after the GitHub release.
- **Blocks on:** open Dependabot, code-scanning or secret-scanning alerts; draft or triage security advisories (private vulnerability reports are on for this repo); open Dependabot PRs; a red latest push run of any workflow on `main` or `dev`; a failed third-party check on either tip (e.g. Cloudflare Workers Builds); real commits on `main` that the release checkout lacks.
- **Warns on:** other open PRs, every open issue (tagged NEW since the last release), merged branches left on the remote.
- **Fails closed:** a check that cannot run (bad token scope, missing `gh`, network) blocks too, so a failed call never reads as "nothing open".
- **Only the user may accept a blocker** (`--ack "<key>"`), and accepted items go in the release commit body.

**Why:** on 2026-09-11 embody.tools sign-in was down ~23h after a dependency bump (#105), specimen submit had been broken 4 days, and the two hotfixes (#111, #112) then sat on `main` without `dev`. This preflight keeps that state from being skipped; the platform e2e gate (#113) is what catches a breaking bump itself. Merge #113 first: the skill wording points at it.

**Verified:**
- `test_release_preflight.py`: 18 passed. The file also imports under TouchDesigner's own Python, so the in-TD test runner's discovery is safe (no module-level pytest).
- Full pytest tier: 3604 passed, 15 skipped (POSIX-only), 0 failed.
- Live repo today: 0 blockers, 11 warnings (PR #44, 6 open issues with 3 new since v6.2.46, 4 stale merged branches).
- Drift control: in a checkout whose `dev` lacks the hotfixes it flags exactly b20bf5e0 and 5b12ca0f; at 11 past release merge points it flags nothing.
- Reviewed by a 3-lens panel (behavior, spec, portability); all three blocking findings are fixed in this version.

Also closes a pre-existing pytest.ini / bridge-tests path-filter gap (`test_tdxn_par_key_migration.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
